### PR TITLE
Add support for Portenta C33 and Nano RP2040 bootloader mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm run publish
 ## 🫶 Adding Support for Other Boards
 To add support for additional boards a few changes / additions may be required:
 - Add a descriptor for the device to [descriptors.js](./firmware-flash/logic/descriptors.js). The descriptor contains the VID and PID of the board plus some instructions on how to flash a firmware.
-- If the board requires a flashing tool other than the ones already supported, it needs to be added to [firmware-flash/bin](./firmware-flash/bin/) and the corresponding Node.js binding needs to be added to [flasher.js](./firmware-flash/logic/flasher.js)
+- If the board requires a flashing tool other than the ones already supported, it needs to be added to [firmware-flash/bin](./firmware-flash/bin/) and the corresponding Node.js binding needs to be added to [commandRunner.js](./firmware-flash/logic/commandRunner.js)
 - An SVG asset of the board needs to be added to [assets/boards](./assets/boards/). The filename will be derived from the board manufacturer and product name in the descriptor.
 
 ## 💪 Contributing

--- a/firmware-flash/index.js
+++ b/firmware-flash/index.js
@@ -2,6 +2,7 @@ import DeviceManager from './logic/deviceManager.js';
 import descriptors from './logic/descriptors.js';
 import Logger from './logic/logger.js';
 import Device from './logic/device.js';
+import SerialDeviceFinder from './logic/deviceDiscovery/serialDeviceFinder.js';
 
 /// The amount of time to wait for the device to become available in bootloader mode.
 /// This is only used for devices that can't be detected in bootloader mode through their serial port.
@@ -16,16 +17,16 @@ async function flashFirmware(firmwarePath, selectedDevice, isMicroPython = false
     }
     logger?.log(`👀 Device found: ${selectedDevice.deviceDescriptor.name} at ${selectedDevice.getSerialPort()}`);
     
-    if(selectedDevice.runsMicroPython()) {
-        let version = await selectedDevice.getMicroPythonVersion();
-        logger?.log(`🐍 Device is running MicroPython version: ${version}`);
-    }
-
     if(selectedDevice.runsBootloader()) {
         logger?.log(`👍 Device is already in bootloader mode.`);
         await selectedDevice.flashFirmware(firmwarePath, isMicroPython);
         logger?.log('✅ Firmware flashed successfully.');
         return true;
+    }
+    
+    if(selectedDevice.runsMicroPython()) {
+        let version = await selectedDevice.getMicroPythonVersion();
+        logger?.log(`🐍 Device is running MicroPython version: ${version}`);
     }
 
     try {
@@ -93,5 +94,6 @@ const deviceManager = new DeviceManager();
 for (const descriptor of descriptors) {
     deviceManager.addDeviceDescriptor(descriptor);
 }
+deviceManager.addDeviceFinder(new SerialDeviceFinder());
 
 export { Device, Logger, flashFirmware, flashMicroPythonFirmware, getDeviceList, getFirstFoundDevice, setLogger, deviceManager };

--- a/firmware-flash/index.js
+++ b/firmware-flash/index.js
@@ -4,6 +4,7 @@ import Logger from './logic/logger.js';
 import Device from './logic/device.js';
 import SerialDeviceFinder from './logic/deviceDiscovery/serialDeviceFinder.js';
 import PicotoolDeviceFinder from './logic/deviceDiscovery/picotoolDeviceFinder.js';
+import DFUDeviceFinder from './logic/deviceDiscovery/dfuDeviceFinder.js';
 
 /// The amount of time to wait for the device to become available in bootloader mode.
 /// This is only used for devices that can't be detected in bootloader mode through their serial port.
@@ -102,5 +103,6 @@ for (const descriptor of Object.values(descriptors)) {
 }
 deviceManager.addDeviceFinder(new SerialDeviceFinder());
 deviceManager.addDeviceFinder(new PicotoolDeviceFinder());
+deviceManager.addDeviceFinder(new DFUDeviceFinder());
 
 export { Device, Logger, flashFirmware, flashMicroPythonFirmware, getDeviceList, getFirstFoundDevice, setLogger, deviceManager };

--- a/firmware-flash/index.js
+++ b/firmware-flash/index.js
@@ -1,8 +1,9 @@
 import DeviceManager from './logic/deviceManager.js';
-import descriptors from './logic/descriptors.js';
+import * as descriptors from './logic/descriptors.js';
 import Logger from './logic/logger.js';
 import Device from './logic/device.js';
 import SerialDeviceFinder from './logic/deviceDiscovery/serialDeviceFinder.js';
+import PicotoolDeviceFinder from './logic/deviceDiscovery/picotoolDeviceFinder.js';
 
 /// The amount of time to wait for the device to become available in bootloader mode.
 /// This is only used for devices that can't be detected in bootloader mode through their serial port.
@@ -15,7 +16,12 @@ async function flashFirmware(firmwarePath, selectedDevice, isMicroPython = false
     if(!selectedDevice.logger){
         selectedDevice.logger = logger;
     }
-    logger?.log(`👀 Device found: ${selectedDevice.deviceDescriptor.name} at ${selectedDevice.getSerialPort()}`);
+    const serialPort = selectedDevice.getSerialPort();
+    if(serialPort) {
+        logger?.log(`👀 Device found: ${selectedDevice.deviceDescriptor.name} at ${serialPort}`);
+    } else {
+        logger?.log(`👀 Device found: ${selectedDevice.deviceDescriptor.name}`);
+    }
     
     if(selectedDevice.runsBootloader()) {
         logger?.log(`👍 Device is already in bootloader mode.`);
@@ -91,9 +97,10 @@ function setLogger(alogger){
 
 const deviceManager = new DeviceManager();
     
-for (const descriptor of descriptors) {
+for (const descriptor of Object.values(descriptors)) {
     deviceManager.addDeviceDescriptor(descriptor);
 }
 deviceManager.addDeviceFinder(new SerialDeviceFinder());
+deviceManager.addDeviceFinder(new PicotoolDeviceFinder());
 
 export { Device, Logger, flashFirmware, flashMicroPythonFirmware, getDeviceList, getFirstFoundDevice, setLogger, deviceManager };

--- a/firmware-flash/index.js
+++ b/firmware-flash/index.js
@@ -11,12 +11,9 @@ import DFUDeviceFinder from './logic/deviceDiscovery/dfuDeviceFinder.js';
 /// An alternative could be to use the device's VID/PID with https://www.npmjs.com/package/usb
 const DEVICE_AWAIT_TIMEOUT = 3000;
 
-let logger;
+let logger = Logger.defaultLogger;
 
 async function flashFirmware(firmwarePath, selectedDevice, isMicroPython = false){
-    if(!selectedDevice.logger){
-        selectedDevice.logger = logger;
-    }
     const serialPort = selectedDevice.getSerialPort();
     if(serialPort) {
         logger?.log(`👀 Device found: ${selectedDevice.deviceDescriptor.name} at ${serialPort}`);
@@ -52,7 +49,6 @@ async function flashFirmware(firmwarePath, selectedDevice, isMicroPython = false
             logger?.log("⌛️ Waiting for bootloader to become available...");
             deviceInBootloaderMode = await deviceManager.waitForDevice(selectedDevice.getBootloaderVID(), selectedDevice.getBootloaderPID());
         }
-        deviceInBootloaderMode.logger = logger;
         logger?.log(`👍 Device is now in bootloader mode.`);
 
         await deviceInBootloaderMode.flashFirmware(firmwarePath, isMicroPython);
@@ -66,9 +62,6 @@ async function flashFirmware(firmwarePath, selectedDevice, isMicroPython = false
 }
 
 async function flashMicroPythonFirmware(selectedDevice, useNightlyBuild = false){
-    if(!selectedDevice.logger){
-        selectedDevice.logger = logger;
-    }
     const firmwareFile = await selectedDevice.downloadMicroPythonFirmware(useNightlyBuild);
     if(!firmwareFile) {
         return false;
@@ -91,11 +84,6 @@ async function getFirstFoundDevice(){
     return foundDevices[0];
 }
 
-function setLogger(alogger){
-    logger = alogger;
-    deviceManager.logger = logger;
-}
-
 const deviceManager = new DeviceManager();
     
 for (const descriptor of Object.values(descriptors)) {
@@ -105,4 +93,4 @@ deviceManager.addDeviceFinder(new SerialDeviceFinder());
 deviceManager.addDeviceFinder(new PicotoolDeviceFinder());
 deviceManager.addDeviceFinder(new DFUDeviceFinder());
 
-export { Device, Logger, flashFirmware, flashMicroPythonFirmware, getDeviceList, getFirstFoundDevice, setLogger, deviceManager };
+export { Device, Logger, flashFirmware, flashMicroPythonFirmware, getDeviceList, getFirstFoundDevice, deviceManager };

--- a/firmware-flash/logic/commandRunner.js
+++ b/firmware-flash/logic/commandRunner.js
@@ -8,7 +8,7 @@ import Logger from './logger.js';
 const __filename = fileURLToPath(import.meta.url);
 
 // TODO: Rename this class to something more appropriate.
-export class Flasher {
+export class CommandRunner {
 
     get logger() {
         if(this._logger === undefined) {
@@ -316,4 +316,4 @@ export class Flasher {
 
 }
 
-export default Flasher;
+export default CommandRunner;

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -11,7 +11,7 @@ const SOFTDEVICE_RELOCATE_DURATION = 7000;
 const SOFT_DEVICE_MAGIC_NUMBER = 1;
 
 const flasher = new Flasher();
-flasher.logger = new Logger(null, true, Logger.LOG_LEVEL.DEBUG);
+const logger = Logger.defaultLogger;
 
 const softDeviceFirmwareFilename = "SoftDeviceUpdater.bin";
 const nanoESP32RecoveryFirmwareFilename = "nora_recovery.ino.bin";
@@ -147,14 +147,12 @@ arduinoNano33BLEDescriptor.onFlashFirmware = async (firmware, device, isMicroPyt
             throw new Error("Bootloader version is too old. Please update it to version 3.0 or higher.");
         }
         */
-        const logger = device.logger;
         const deviceManager = device.getDeviceManager();
     
         logger.log("🔥 Flashing SoftDevice updater...");
         await flasher.runBossac(getSoftDeviceFirmwarePath(), device.getSerialPort());
         logger.log("🏃 Waiting for device to run sketch...");
         let deviceInArduinoMode = await deviceManager.waitForDeviceToEnterArduinoMode(device, 10);
-        deviceInArduinoMode.logger = logger;
     
         logger.log("🪄 Sending magic number to device...");
         // Write one byte (1) to the serial port to tell the device to flash the bootloader / softdevice.
@@ -172,7 +170,6 @@ arduinoNano33BLEDescriptor.onFlashFirmware = async (firmware, device, isMicroPyt
         if(!deviceInBootloaderMode){
             throw new Error("❌ Failed to flash SoftDevice.");
         }
-        deviceInBootloaderMode.logger = logger;
 
         logger.log(`🔥 Installing MicroPython...`);
         await flasher.runBossac(firmware, deviceInBootloaderMode.getSerialPort(), arduinoNano33BLEUPythonOffset);

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -219,7 +219,7 @@ arduinoNanoESP32NativeDescriptor.onFlashFirmware = async (firmware, device, isMi
     await flasher.runEsptool([firmwareCommand, recoveryCommand], device.getSerialPort(), config);
 };
 
-const descriptors = [
+export {
     arduinoPortentaC33Descriptor,
     arduinoGigaDescriptor, 
     arduinoPortentaH7Descriptor, 
@@ -228,6 +228,4 @@ const descriptors = [
     arduinoNano33BLEDescriptor,
     arduinoNanoESP32Descriptor,
     arduinoNanoESP32NativeDescriptor
-];
-
-export default descriptors;
+};

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -4,6 +4,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import Logger from './logger.js';
 
+//TODO: Add discoveryModes property to the device descriptor to indicate supported modes for the device finders.
+
 /// The amount of time to wait for the softdevice to be relocated to the final location in the flash.
 const SOFTDEVICE_RELOCATE_DURATION = 7000;
 
@@ -100,6 +102,7 @@ arduinoNanoRP2040Descriptor.onFlashFirmware = async (firmware, device, isMicroPy
 };
 
 // Device doesn't expose a serial port in bootloader mode
+// TODO: Now that we detect the board in bootloader, we can probably wait for it to appear
 arduinoNanoRP2040Descriptor.skipWaitForDevice = true;
 
 const arduinoNiclaVisionIdentifiers = {

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -4,8 +4,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import Logger from './logger.js';
 
-//TODO: Add discoveryModes property to the device descriptor to indicate supported modes for the device finders.
-
 /// The amount of time to wait for the softdevice to be relocated to the final location in the flash.
 const SOFTDEVICE_RELOCATE_DURATION = 7000;
 
@@ -70,7 +68,6 @@ arduinoPortentaC33Descriptor.onFlashFirmware = async (firmware, device, isMicroP
     
     throw new Error("❌ Invalid firmware file");
 };
-arduinoPortentaC33Descriptor.skipWaitForDevice = true;
 
 const arduinoGigaIdentifiers = {
     "default" : {

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -98,10 +98,6 @@ arduinoNanoRP2040Descriptor.onFlashFirmware = async (firmware, device, isMicroPy
     await flasher.runPicotool(firmware, device.getVendorIDHex(), device.getProductIDHex());
 };
 
-// Device doesn't expose a serial port in bootloader mode
-// TODO: Now that we detect the board in bootloader, we can probably wait for it to appear
-arduinoNanoRP2040Descriptor.skipWaitForDevice = true;
-
 const arduinoNiclaVisionIdentifiers = {
     "default" : {
         "vid" : 0x2341,

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -1,5 +1,5 @@
 import DeviceDescriptor from './deviceDescriptor.js';
-import Flasher from './flasher.js';
+import CommandRunner from './commandRunner.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import Logger from './logger.js';
@@ -10,7 +10,7 @@ const SOFTDEVICE_RELOCATE_DURATION = 7000;
 /// The magic number sent by the device to indicate that the softdevice has been flashed.
 const SOFT_DEVICE_MAGIC_NUMBER = 1;
 
-const flasher = new Flasher();
+const commandRunner = new CommandRunner();
 const logger = Logger.defaultLogger;
 
 const softDeviceFirmwareFilename = "SoftDeviceUpdater.bin";
@@ -40,12 +40,12 @@ const arduinoPortentaH7Descriptor = new DeviceDescriptor(arduinoPortentaH7Identi
 arduinoPortentaH7Descriptor.onFlashFirmware = async (firmware, device, isMicroPython) => {
     // Check if firmware is a DFU file
     if(firmware.endsWith(".dfu")){
-        await flasher.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), true);
+        await commandRunner.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), true);
         return;
     }
     // Check if firmware is a binary file
     if(firmware.endsWith(".bin")){
-        await flasher.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), true, true, "0x08040000");
+        await commandRunner.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), true, true, "0x08040000");
         return;
     }
 
@@ -62,7 +62,7 @@ const arduinoPortentaC33Descriptor = new DeviceDescriptor(arduinoPortentaC33Iden
 arduinoPortentaC33Descriptor.onFlashFirmware = async (firmware, device, isMicroPython) => {
     // Check if firmware is a binary file
     if(firmware.endsWith(".bin")){
-        await flasher.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), false);
+        await commandRunner.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), false);
         return;
     }
     
@@ -95,7 +95,7 @@ const arduinoNanoRP2040Identifiers = {
 };
 const arduinoNanoRP2040Descriptor = new DeviceDescriptor(arduinoNanoRP2040Identifiers, 'Nano RP2040 Connect', 'Arduino', 'ARDUINO_NANO_RP2040_CONNECT', 'uf2');
 arduinoNanoRP2040Descriptor.onFlashFirmware = async (firmware, device, isMicroPython) => {
-    await flasher.runPicotool(firmware, device.getVendorIDHex(), device.getProductIDHex());
+    await commandRunner.runPicotool(firmware, device.getVendorIDHex(), device.getProductIDHex());
 };
 
 const arduinoNiclaVisionIdentifiers = {
@@ -106,7 +106,7 @@ const arduinoNiclaVisionIdentifiers = {
 };
 const arduinoNiclaVisionDescriptor = new DeviceDescriptor(arduinoNiclaVisionIdentifiers, 'Nicla Vision', 'Arduino', 'ARDUINO_NICLA_VISION', 'dfu');
 arduinoNiclaVisionDescriptor.onFlashFirmware = async (firmware, device, isMicroPython) => {
-    await flasher.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), true);
+    await commandRunner.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), true);
 };
 
 const arduinoNano33BLEIdentifiers = {
@@ -129,13 +129,14 @@ const arduinoNano33BLEUPythonOffset = "0x16000";
 
 const arduinoNano33BLEDescriptor = new DeviceDescriptor(arduinoNano33BLEIdentifiers, 'Nano 33 BLE', 'Arduino', 'arduino_nano_33_ble_sense', 'bin');
 arduinoNano33BLEDescriptor.onReset = async (device) => {
-    await flasher.resetBoardWithBossac(device.getSerialPort());
+    await commandRunner.resetBoardWithBossac(device.getSerialPort());
 };
 
 arduinoNano33BLEDescriptor.onFlashFirmware = async (firmware, device, isMicroPython) => {
     if(isMicroPython){
         /*
-        const bootloaderVersion = await flasher.getBootloaderVersionWithBossac(device.serialPort);
+        // Doesn't work because the bootloader version wasn't updated in the bootloader.
+        const bootloaderVersion = await commandRunner.getBootloaderVersionWithBossac(device.serialPort);
         const majorVersion = parseInt(bootloaderVersion.split(".")[0]);
         console.log("👢 Bootloader version: " + bootloaderVersion);
         
@@ -146,7 +147,7 @@ arduinoNano33BLEDescriptor.onFlashFirmware = async (firmware, device, isMicroPyt
         const deviceManager = device.getDeviceManager();
     
         logger.log("🔥 Flashing SoftDevice updater...");
-        await flasher.runBossac(getSoftDeviceFirmwarePath(), device.getSerialPort());
+        await commandRunner.runBossac(getSoftDeviceFirmwarePath(), device.getSerialPort());
         logger.log("🏃 Waiting for device to run sketch...");
         let deviceInArduinoMode = await deviceManager.waitForDeviceToEnterArduinoMode(device, 10);
     
@@ -168,9 +169,9 @@ arduinoNano33BLEDescriptor.onFlashFirmware = async (firmware, device, isMicroPyt
         }
 
         logger.log(`🔥 Installing MicroPython...`);
-        await flasher.runBossac(firmware, deviceInBootloaderMode.getSerialPort(), arduinoNano33BLEUPythonOffset);
+        await commandRunner.runBossac(firmware, deviceInBootloaderMode.getSerialPort(), arduinoNano33BLEUPythonOffset);
     } else {
-        await flasher.runBossac(firmware, device.getSerialPort());
+        await commandRunner.runBossac(firmware, device.getSerialPort());
     }
         
 };
@@ -192,7 +193,7 @@ arduinoNanoESP32Descriptor.onFlashFirmware = async (firmware, device, isMicroPyt
     if(path.extname(firmware) == ".bin"){
         throw new Error("❌ Installing a raw binary from DFU bootloader is not supported. Please use the native bootloader instead or flash an application image.");
     }
-    await flasher.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), false);
+    await commandRunner.runDfuUtil(firmware, device.getVendorIDHex(), device.getProductIDHex(), false);
 };
 
 const arduinoNanoESP32NativeIdentifiers = {
@@ -209,7 +210,7 @@ arduinoNanoESP32NativeDescriptor.onFlashFirmware = async (firmware, device, isMi
     const config = {"chip": "esp32s3", "flashSize" : "16MB", "flashMode" : "dio", "flashFreq" : "80m"};
     const recoveryCommand = {"address" : "0xf70000", "path" : getNanoESP32RecoveryFirmwarePath()};
     const firmwareCommand = {"address" : "0x0", "path" : firmware};
-    await flasher.runEsptool([firmwareCommand, recoveryCommand], device.getSerialPort(), config);
+    await commandRunner.runEsptool([firmwareCommand, recoveryCommand], device.getSerialPort(), config);
 };
 
 export {

--- a/firmware-flash/logic/device.js
+++ b/firmware-flash/logic/device.js
@@ -10,14 +10,14 @@ const HOST_URL = "https://downloads.arduino.cc";
 const JSON_URL = HOST_URL + "/micropython/index.json";
 
 export class Device {
-    constructor(vendorID, productID, deviceDescriptor, serialPort = null, serialNumber = null) {
+    constructor(vendorID, productID, serialPort = null, serialNumber = null) {
         this.vendorID = vendorID;
         this.productID = productID;
-        this.deviceDescriptor = deviceDescriptor;
         this.serialNumber = serialNumber;
         this.serialPort = serialPort;
         this.logger = null;
         this.deviceManager = null;
+        this.deviceDescriptor = null;
     }
 
     async getUPythonFirmwareUrl(useNightlyBuild = false) {
@@ -314,6 +314,10 @@ export class Device {
     // The number is padded with a 0 if it is less than 4 digits long.
     convertNumberToHex(anID) {
         return "0x" + anID.toString(16).padStart(4, '0');
+    }
+
+    setDeviceDescriptor(deviceDescriptor) {
+        this.deviceDescriptor = deviceDescriptor;
     }
 
     getVendorID() {

--- a/firmware-flash/logic/device.js
+++ b/firmware-flash/logic/device.js
@@ -15,9 +15,19 @@ export class Device {
         this.productID = productID;
         this.serialNumber = serialNumber;
         this.serialPort = serialPort;
-        this.logger = null;
         this.deviceManager = null;
         this.deviceDescriptor = null;
+    }
+
+    get logger() {
+        if(this._logger === undefined) {
+            return Logger.defaultLogger;
+        }
+        return this._logger;
+    }
+
+    set logger(logger) {
+        this._logger = logger;
     }
 
     async getUPythonFirmwareUrl(useNightlyBuild = false) {

--- a/firmware-flash/logic/deviceDescriptor.js
+++ b/firmware-flash/logic/deviceDescriptor.js
@@ -9,7 +9,7 @@ export class DeviceDescriptor {
         this.onFlashFirmware = null;
         this.onReset = null;
         // Currently used to skip the wait for device step when the device 
-        // cannot be detected via its serial port.
+        // cannot be detected via its serial port or DFU interface.
         this.skipWaitForDevice = false;
     }
 

--- a/firmware-flash/logic/deviceDiscovery/deviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/deviceFinder.js
@@ -16,6 +16,10 @@ class DeviceFinder {
         return parseInt(anID, 16);
     }
 
+    async getDeviceList() {
+        throw new Error("❌ The getDeviceList() method must be implemented by the subclass.");
+    }
+
 }
 
 export default DeviceFinder;

--- a/firmware-flash/logic/deviceDiscovery/deviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/deviceFinder.js
@@ -1,0 +1,21 @@
+class DeviceFinder {
+
+    // Function to convert a hex string ID to a number.
+    convertHexToNumber(anID) {
+        // The hex string can have the 0x prefix or not.
+        if (anID.startsWith("0x")) {
+            anID = anID.substring(2);
+        }
+        // The hex string can be padded with a 0 or not.
+        if (anID.length === 3) {
+            anID = "0" + anID;
+        }
+        // The hex string can be upper or lower case.
+        anID = anID.toLowerCase();
+
+        return parseInt(anID, 16);
+    }
+
+}
+
+export default DeviceFinder;

--- a/firmware-flash/logic/deviceDiscovery/deviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/deviceFinder.js
@@ -1,4 +1,17 @@
+import Logger from "../logger.js";
+
 class DeviceFinder {
+
+    get logger() {
+        if(this._logger === undefined) {
+            return Logger.defaultLogger;
+        }
+        return this._logger;
+    }
+
+    set logger(logger) {
+        this._logger = logger;
+    }
 
     // Function to convert a hex string ID to a number.
     convertHexToNumber(anID) {

--- a/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
@@ -8,8 +8,6 @@ class DFUDeviceFinder extends DeviceFinder {
 
     async getDeviceList() {
         const flasher = new Flasher();
-        const logger = new Logger(null, true, Logger.LOG_LEVEL.DEBUG);
-        flasher.logger = logger;
         try {
             const deviceInfo = await flasher.getDeviceListFromDFUUtil();
             /* 
@@ -60,7 +58,7 @@ class DFUDeviceFinder extends DeviceFinder {
             return devices;            
 
         } catch (error) {
-            logger.log(error, Logger.LOG_LEVEL.ERROR);
+            this.logger.log(error, Logger.LOG_LEVEL.ERROR);
             return [];
         }
     }

--- a/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
@@ -1,15 +1,15 @@
 import Device from '../device.js';
 import DeviceFinder from './deviceFinder.js';
-import Flasher from '../flasher.js';
+import CommandRunner from '../commandRunner.js';
 import Logger from '../logger.js';
 import * as descriptors from '../descriptors.js';
 
 class DFUDeviceFinder extends DeviceFinder {
 
     async getDeviceList() {
-        const flasher = new Flasher();
+        const commandRunner = new CommandRunner();
         try {
-            const deviceInfo = await flasher.getDeviceListFromDFUUtil();
+            const deviceInfo = await commandRunner.getDeviceListFromDFUUtil();
             /* 
             Extract the board name from the output of picotool info -l
             Example output:

--- a/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
@@ -1,0 +1,53 @@
+import Device from '../device.js';
+import DeviceFinder from './deviceFinder.js';
+import Flasher from '../flasher.js';
+import Logger from '../logger.js';
+import { arduinoPortentaC33Descriptor } from '../descriptors.js';
+
+class DFUDeviceFinder extends DeviceFinder {
+
+    async getDeviceList() {
+        const flasher = new Flasher();
+        const logger = new Logger(null, true, Logger.LOG_LEVEL.DEBUG);
+        flasher.logger = logger;
+        try {
+            const deviceInfo = await flasher.getDeviceListFromDFUUtil();
+            /* 
+            Extract the board name from the output of picotool info -l
+            Example output:
+            dfu-util 0.11-arduino4
+
+            Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+            Copyright 2010-2021 Tormod Volden and Stefan Schmidt
+            This program is Free Software and has ABSOLUTELY NO WARRANTY
+            Please report bugs to http://sourceforge.net/p/dfu-util/tickets/
+
+            Found DFU: [2341:0368] ver=0100, devnum=38, cfg=1, intf=0, path="20-3", alt=0, name="@CodeFlash /0x00000000/8*8Ka,63*32Kg", serial="4206546E3536353291C846534E4B2CC7"
+            Found DFU: [2341:0368] ver=0100, devnum=38, cfg=1, intf=0, path="20-3", alt=1, name="@DataFlash /0x08000000/8*1Kg", serial="4206546E3536353291C846534E4B2CC7"
+            */
+
+            const identifiersMatch = deviceInfo.match(/Found DFU: \[(\d{4}):(\d{4})\]/);
+            if(!identifiersMatch) {
+                return [];
+            }
+            const vid = this.convertHexToNumber("0x" + identifiersMatch[1]);
+            const pid = this.convertHexToNumber("0x" + identifiersMatch[2]);
+            
+            // Use the VID and PID from the Portenta C33 bootloader
+            const targetVID = arduinoPortentaC33Descriptor.getDefaultIDs().vid;
+            const targetPID = arduinoPortentaC33Descriptor.getDefaultIDs().pids.bootloader;
+
+            if(vid === targetVID && pid === targetPID) {
+                const newDevice = new Device(vid, pid);
+                return [newDevice];
+            }
+            return [];            
+
+        } catch (error) {
+            logger.log(error, Logger.LOG_LEVEL.ERROR);
+            return [];
+        }
+    }
+}
+
+export default DFUDeviceFinder;

--- a/firmware-flash/logic/deviceDiscovery/picotoolDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/picotoolDeviceFinder.js
@@ -1,0 +1,47 @@
+import Device from '../device.js';
+import DeviceFinder from './deviceFinder.js';
+import Flasher from '../flasher.js';
+import Logger from '../logger.js';
+import { arduinoNanoRP2040Descriptor } from '../descriptors.js';
+
+const PICO_BOARD_NAME = 'arduino_nano_rp2040_connect';
+
+class PicotoolDeviceFinder extends DeviceFinder {
+
+    async getDeviceList() {
+        const flasher = new Flasher();
+        const logger = new Logger(null, true, Logger.LOG_LEVEL.DEBUG);
+        flasher.logger = logger;
+        try {
+            const boardInfo = await flasher.getBoardInfoWithPicotool();
+            /* 
+            Extract the board name from the output of picotool info -l
+            Example output:
+            Build Information
+                sdk version:       1.5.0
+                pico_board:        arduino_nano_rp2040_connect
+                boot2_name:        boot2_w25q080
+                build date:        Apr 26 2023
+                build attributes:  MinSizeRel
+            */
+
+            const boardNameMatch = boardInfo.match(/pico_board:\s+(\S+)/);
+            const boardName = boardNameMatch ? boardNameMatch[1] : null;
+    
+            if(boardName === PICO_BOARD_NAME) {
+                // Use the VID and PID from the RP2040 native bootloader
+                const vid = arduinoNanoRP2040Descriptor.getAlternativeIDs().vid;
+                const pid = arduinoNanoRP2040Descriptor.getAlternativeIDs().pids.bootloader;
+                const newDevice = new Device(vid, pid);
+                return [newDevice];
+            }
+            return [];            
+
+        } catch (error) {
+            logger.log(error, Logger.LOG_LEVEL.ERROR);
+            return [];
+        }
+    }
+}
+
+export default PicotoolDeviceFinder;

--- a/firmware-flash/logic/deviceDiscovery/picotoolDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/picotoolDeviceFinder.js
@@ -1,6 +1,6 @@
 import Device from '../device.js';
 import DeviceFinder from './deviceFinder.js';
-import Flasher from '../flasher.js';
+import CommandRunner from '../commandRunner.js';
 import Logger from '../logger.js';
 import { arduinoNanoRP2040Descriptor } from '../descriptors.js';
 
@@ -9,9 +9,9 @@ const PICO_BOARD_NAME = 'arduino_nano_rp2040_connect';
 class PicotoolDeviceFinder extends DeviceFinder {
 
     async getDeviceList() {
-        const flasher = new Flasher();
+        const commandRunner = new CommandRunner();
         try {
-            const boardInfo = await flasher.getBoardInfoWithPicotool();
+            const boardInfo = await commandRunner.getBoardInfoWithPicotool();
             /* 
             Extract the board name from the output of picotool info -l
             Example output:

--- a/firmware-flash/logic/deviceDiscovery/picotoolDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/picotoolDeviceFinder.js
@@ -10,8 +10,6 @@ class PicotoolDeviceFinder extends DeviceFinder {
 
     async getDeviceList() {
         const flasher = new Flasher();
-        const logger = new Logger(null, true, Logger.LOG_LEVEL.DEBUG);
-        flasher.logger = logger;
         try {
             const boardInfo = await flasher.getBoardInfoWithPicotool();
             /* 
@@ -38,7 +36,7 @@ class PicotoolDeviceFinder extends DeviceFinder {
             return [];            
 
         } catch (error) {
-            logger.log(error, Logger.LOG_LEVEL.ERROR);
+            this.logger.log(error, Logger.LOG_LEVEL.ERROR);
             return [];
         }
     }

--- a/firmware-flash/logic/deviceDiscovery/serialDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/serialDeviceFinder.js
@@ -1,0 +1,22 @@
+import { SerialPort } from 'serialport'
+import Device from '../device.js';
+import DeviceFinder from './deviceFinder.js';
+
+class SerialDeviceFinder extends DeviceFinder {
+
+    async getDeviceList() {
+        let devices = [];
+        const ports = await SerialPort.list();
+
+        for (const port of ports) {
+            if(port.vendorId === undefined || port.productId === undefined) continue;
+            const vendorID = this.convertHexToNumber(port.vendorId);
+            const productID = this.convertHexToNumber(port.productId);
+            const newDevice = new Device(vendorID, productID, port.path, port.serialNumber);
+            devices.push(newDevice);
+        }
+        return devices;
+    }
+}
+
+export default SerialDeviceFinder;

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -87,6 +87,13 @@ class DeviceManager {
         });
     }    
 
+    /**
+     * Refreshes the list of connected devices. It uses the device finders to find the devices.
+     * The device descriptors are used to filter the devices and only list the ones that are supported.
+     * The registered device finders are used in the order they were added.
+     * If a device gets added to the list by a device finder, it will not be added again by another device finder.
+     * Consequently, the order of the device finders is important.
+     */
     async refreshDeviceList() {
         this.devices = [];
         
@@ -101,7 +108,15 @@ class DeviceManager {
 
                 if (deviceDescriptor) {
                     foundDevice.setDeviceDescriptor(deviceDescriptor);
-                    this.devices.push(foundDevice);
+                    foundDevice.deviceManager = this;
+                    foundDevice.logger = this.logger;
+                    if (!this.devices.find(device => 
+                                            device.getVendorID() === foundDevice.getVendorID() && 
+                                            device.getProductID() === foundDevice.getProductID())) {
+                        this.devices.push(foundDevice);
+                    } else {
+                        this.logger?.log(`ℹ️ ${deviceFinder.constructor.name}: Device with VID ${foundDevice.getVendorID()} and PID ${foundDevice.getProductID()} already exists in list. Skipping.`, Logger.LOG_LEVEL.DEBUG);
+                    }
                 }
             }
         }

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -1,4 +1,3 @@
-import { SerialPort } from 'serialport'
 import Device from './device.js';
 import Logger from './logger.js';
 
@@ -6,8 +5,18 @@ class DeviceManager {
     constructor() {
       this.devices = null;
       this.deviceDescriptors = [];
-      this.logger = null;
       this.deviceFinders = [];
+    }
+
+    get logger() {
+        if(this._logger === undefined) {
+            return Logger.defaultLogger;
+        }
+        return this._logger;
+    }
+
+    set logger(logger) {
+        this._logger = logger;
     }
 
     addDeviceFinder(deviceFinder) {
@@ -109,7 +118,6 @@ class DeviceManager {
                 if (deviceDescriptor) {
                     foundDevice.setDeviceDescriptor(deviceDescriptor);
                     foundDevice.deviceManager = this;
-                    foundDevice.logger = this.logger;
                     if (!this.devices.find(device => 
                                             device.getVendorID() === foundDevice.getVendorID() && 
                                             device.getProductID() === foundDevice.getProductID())) {

--- a/firmware-flash/logic/flasher.js
+++ b/firmware-flash/logic/flasher.js
@@ -10,6 +10,18 @@ const __filename = fileURLToPath(import.meta.url);
 // TODO: Rename this class to something more appropriate.
 export class Flasher {
 
+    get logger() {
+        if(this._logger === undefined) {
+            return Logger.defaultLogger;
+        }
+        return this._logger;
+    }
+
+    set logger(logger) {
+        this._logger = logger;
+    }
+
+
     /**
      * Get binary folder based on the operating system and the architecture.
      * @param {String} binaryName the name of the command line tool to run

--- a/firmware-flash/logic/flasher.js
+++ b/firmware-flash/logic/flasher.js
@@ -163,7 +163,35 @@ export class Flasher {
             });
         });
     }
+    
+    async getBoardInfoWithPicotool() {
+        const logger = this.logger;
+        const picotoolPath = this.getBinaryPath("picotool");
+        let cmd = `"${picotoolPath}" info -l`;
         
+        return new Promise((resolve, reject) => {
+            exec(cmd, (error, stdout, stderr) => {
+                if(error && stdout.trim() == "No accessible RP2040 devices in BOOTSEL mode were found."){
+                    logger?.log(stdout, Logger.LOG_LEVEL.DEBUG);
+                    resolve(stdout);
+                    return;
+                }
+
+                if (error) {
+                    logger?.log(error.message, Logger.LOG_LEVEL.DEBUG);
+                    reject(`Error running picotool: ${error.message}`);
+                    return;
+                }
+                
+                if (stderr) {
+                    reject(`Error running picotool: ${stderr}`);
+                    return;
+                }
+                logger?.log(stdout, Logger.LOG_LEVEL.DEBUG);
+                resolve(stdout);
+            });
+        });
+    }
 
     async runPicotool(firmwareFilepath, reset = true) {
         const logger = this.logger;

--- a/firmware-flash/logic/flasher.js
+++ b/firmware-flash/logic/flasher.js
@@ -72,6 +72,7 @@ export class Flasher {
                         resolve(stdout);
                         return;
                     }
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running dfu-util (stderr): '${stderr}'`);
                     return;
                 }
@@ -104,6 +105,7 @@ export class Flasher {
                     return;
                 }
                 if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running bossac: ${stderr}`);
                     return;
                 }
@@ -127,6 +129,7 @@ export class Flasher {
                     return;
                 }
                 if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running bossac: ${stderr}`);
                     return;
                 }                
@@ -155,6 +158,7 @@ export class Flasher {
                     return;
                 }
                 if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running bossac: ${stderr}`);
                     return;
                 }
@@ -184,6 +188,7 @@ export class Flasher {
                 }
                 
                 if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running picotool: ${stderr}`);
                     return;
                 }
@@ -212,6 +217,7 @@ export class Flasher {
                     return;
                 }
                 if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running picotool: ${stderr}`);
                     return;
                 }
@@ -245,6 +251,7 @@ export class Flasher {
                         return;
                     }
                     if (stderr) {
+                        logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                         reject(`Error running esptool: ${stderr}`);
                         return;
                     }
@@ -262,6 +269,7 @@ export class Flasher {
                     return;
                 }
                 if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
                     reject(`Error running esptool: ${stderr}`);
                     return;
                 }

--- a/firmware-flash/logic/flasher.js
+++ b/firmware-flash/logic/flasher.js
@@ -40,6 +40,28 @@ export class Flasher {
         return binaryPath;
     }
 
+    async getDeviceListFromDFUUtil() {
+        const logger = this.logger;
+        const dfuUtilPath = this.getBinaryPath("dfu-util");
+        const cmd = `"${dfuUtilPath}" -l`;
+        return new Promise((resolve, reject) => {
+            exec(cmd, (error, stdout, stderr) => {
+                if (error) {
+                    logger?.log(error.message, Logger.LOG_LEVEL.DEBUG);
+                    reject(`Error running dfu-util: '${error.message}'`);
+                    return;
+                }
+                if (stderr) {
+                    logger?.log(stderr, Logger.LOG_LEVEL.DEBUG);
+                    reject(`Error running dfu-util (stderr): '${stderr}'`);
+                    return;
+                }
+                logger?.log(stdout, Logger.LOG_LEVEL.DEBUG);
+                resolve(stdout);
+            });
+        });
+    }
+
     async runDfuUtil(firmwareFilepath, vendorId, productId, dfuseDevice, reset = true, offset = null) {
         const logger = this.logger;
         const dfuUtilPath = this.getBinaryPath("dfu-util");

--- a/firmware-flash/logic/flasher.js
+++ b/firmware-flash/logic/flasher.js
@@ -7,6 +7,7 @@ import Logger from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
+// TODO: Rename this class to something more appropriate.
 export class Flasher {
 
     /**

--- a/firmware-flash/logic/logger.js
+++ b/firmware-flash/logic/logger.js
@@ -1,4 +1,14 @@
+let defaultLogger;
+
 class Logger {
+
+    static get defaultLogger() {
+        if(!defaultLogger) {
+            defaultLogger = new Logger();
+        }
+        return defaultLogger;
+    }
+
     // Enum for log levels
     static get LOG_LEVEL() {
         return {
@@ -10,19 +20,28 @@ class Logger {
         };
     }
 
-    constructor(onLog, printToConsole = false, logLevel = Logger.LOG_LEVEL.INFO) {
-        this.onLog = onLog;
+    constructor(onLog = null, printToConsole = true, logLevel = Logger.LOG_LEVEL.INFO) {
+        this.onLogCallback = onLog;
         this.printToConsole = printToConsole;
         this.logLevel = logLevel;
     }
+
+    set onLog(onLogCallback) {
+        this.onLogCallback = onLogCallback;
+    }
+
+    setLogLevel(logLevel) {
+        this.logLevel = logLevel;
+    }
+
 
     log(message, level = Logger.LOG_LEVEL.INFO) {
         if(level < this.logLevel) {
             return;
         }
 
-        if(this.onLog) {
-            this.onLog(message, level);
+        if(this.onLogCallback) {
+            this.onLogCallback(message, level);
         }
 
         if(this.printToConsole) {

--- a/main.js
+++ b/main.js
@@ -40,8 +40,9 @@ const forwardOutput = (message, level) => {
 
 app.whenReady().then(async () => {
     flash = await import('firmware-flash');
-    logger = new flash.Logger(forwardOutput, true, flash.Logger.LOG_LEVEL.DEBUG);
-    flash.setLogger(logger);
+    logger = flash.Logger.defaultLogger;
+    logger.onLog = forwardOutput;
+    logger.setLogLevel(flash.Logger.LOG_LEVEL.DEBUG);
     createWindow()
 })
 


### PR DESCRIPTION
This PR expands on the device discovery and allows to detect boards through different ways other than the Serial port. DFU-Util is used to do so for C33 and picotool for the Nano RP2040.