### PR TITLE
Fix installation on Portenta C33

### DIFF
--- a/check-validity-macos.sh
+++ b/check-validity-macos.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This script can be used to check the validity of a codesigned app on macOS.
+# It runs both codesign and Gatekeeper assessments.
+# Example usage: ./check-validity-macos.sh ""./out/MicroPython Installer-darwin-x64/MicroPython Installer.app"
+
 codesign --verify --verbose=1 "$1"
 if [ $? -ne 0 ]; then
     echo "❌ Codesign verification failed. Exiting..."

--- a/firmware-flash/logic/commandRunner.js
+++ b/firmware-flash/logic/commandRunner.js
@@ -7,7 +7,6 @@ import Logger from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
-// TODO: Rename this class to something more appropriate.
 export class CommandRunner {
 
     get logger() {
@@ -69,7 +68,7 @@ export class CommandRunner {
                     reject(`Error running dfu-util (stderr): '${stderr}'`);
                     return;
                 }
-                logger?.log(stdout, Logger.LOG_LEVEL.DEBUG);
+                
                 resolve(stdout);
             });
         });
@@ -211,7 +210,8 @@ export class CommandRunner {
         return new Promise((resolve, reject) => {
             exec(cmd, (error, stdout, stderr) => {
                 if(error && stdout.trim() == "No accessible RP2040 devices in BOOTSEL mode were found."){
-                    logger?.log(stdout, Logger.LOG_LEVEL.DEBUG);
+                    const message = "🔌 No RP2040 device found.";
+                    logger?.log(message, Logger.LOG_LEVEL.DEBUG);
                     resolve(stdout);
                     return;
                 }

--- a/firmware-flash/logic/descriptors.js
+++ b/firmware-flash/logic/descriptors.js
@@ -58,7 +58,7 @@ const arduinoPortentaC33Identifiers = {
         "pids" : {"arduino" : 0x0068, "bootloader" : 0x0368, "upython" : 0x0468 }
     },
 };
-const arduinoPortentaC33Descriptor = new DeviceDescriptor(arduinoPortentaC33Identifiers, 'Portenta C33', 'Arduino', 'ARDUINO_PORTENTA_C33', 'dfu');
+const arduinoPortentaC33Descriptor = new DeviceDescriptor(arduinoPortentaC33Identifiers, 'Portenta C33', 'Arduino', 'ARDUINO_PORTENTA_C33', 'bin');
 arduinoPortentaC33Descriptor.onFlashFirmware = async (firmware, device, isMicroPython) => {
     // Check if firmware is a binary file
     if(firmware.endsWith(".bin")){

--- a/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
@@ -24,8 +24,8 @@ class DFUDeviceFinder extends DeviceFinder {
             Found DFU: [2341:0368] ver=0100, devnum=38, cfg=1, intf=0, path="20-3", alt=1, name="@DataFlash /0x08000000/8*1Kg", serial="4206546E3536353291C846534E4B2CC7"
             */
 
-            const identifiersMatches = deviceInfo.matchAll(/Found DFU: \[(\d{4}):(\d{4})\]/g);
-            if(identifiersMatches.next().done) {
+            const identifiersMatches = [...deviceInfo.matchAll(/Found DFU: \[(\d{4}):(\d{4})\]/g)];
+            if(identifiersMatches.length === 0) {
                 const message = "🔌 No DFU capable USB device found.";
                 this.logger.log(message, Logger.LOG_LEVEL.DEBUG);
                 return [];

--- a/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/dfuDeviceFinder.js
@@ -25,7 +25,9 @@ class DFUDeviceFinder extends DeviceFinder {
             */
 
             const identifiersMatches = deviceInfo.matchAll(/Found DFU: \[(\d{4}):(\d{4})\]/g);
-            if(!identifiersMatches) {
+            if(identifiersMatches.next().done) {
+                const message = "🔌 No DFU capable USB device found.";
+                this.logger.log(message, Logger.LOG_LEVEL.DEBUG);
                 return [];
             }
 

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -123,7 +123,7 @@ class DeviceManager {
                                             device.getProductID() === foundDevice.getProductID())) {
                         this.devices.push(foundDevice);
                     } else {
-                        this.logger?.log(`ℹ️ ${deviceFinder.constructor.name}: Device with VID ${foundDevice.getVendorID()} and PID ${foundDevice.getProductID()} already exists in list. Skipping.`, Logger.LOG_LEVEL.DEBUG);
+                        this.logger?.log(`⏭️ ${deviceFinder.constructor.name}: Device with VID ${foundDevice.getVendorID()} and PID ${foundDevice.getProductID()} already exists in list. Skipping.`, Logger.LOG_LEVEL.DEBUG);
                     }
                 }
             }

--- a/lib/statusTextAnimator.js
+++ b/lib/statusTextAnimator.js
@@ -62,4 +62,11 @@ class StatusTextAnimator {
         }, speed);
       }
 
+      clearStatusText() {
+        this.target.textContent = '';
+        clearTimeout(this.fadeOutTimeout);
+        this.target.style.visibility = 'hidden';
+        this.animationRunning = false;
+      }
+
 }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 if (require('electron-squirrel-startup')) return;
 
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path')
 
 // Handle events from windows squirrel installer
@@ -119,6 +119,10 @@ ipcMain.handle('on-get-devices', async (event, arg) => {
             resolve(pojos);
         }
     });
+});
+
+ipcMain.handle('dialog', (event, method, params) => {
+    dialog[method](win, params);
 });
 
 function handleSquirrelEvent() {

--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ ipcMain.handle('on-custom-install', async (event, data) => {
         const selectedDevice = flash.deviceManager.getDevice(deviceData.vendorID, deviceData.productID);
         try {
             if(!selectedDevice){
-                reject("❌ Selected is not available. Click 'Refresh' to update the list of devices.");
+                reject("❌ Selected device is not available. Click 'Refresh' to update the list of devices.");
                 return;
             }
             if (await flash.flashFirmware(filePath, selectedDevice)) {
@@ -90,7 +90,7 @@ ipcMain.handle('on-install', async (event, data) => {
         const selectedDevice = flash.deviceManager.getDevice(deviceData.vendorID, deviceData.productID);
         try {
             if(!selectedDevice){
-                reject("❌ Selected is not available. Click 'Refresh' to update the list of devices.");
+                reject("❌ Selected device is not available. Click 'Refresh' to update the list of devices.");
                 return;
             }
             if (await flash.flashMicroPythonFirmware(selectedDevice, useNightlyBuild)) {

--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ app.on('activate', () => {
     }
 })
 
-ipcMain.handle('on-file-selected', async (event, data) => {
+ipcMain.handle('on-custom-install', async (event, data) => {
     const { deviceData, filePath } = data;
     logger.log(`⤵️ Data received from UI: '${Object.keys(data)}'`, flash.Logger.LOG_LEVEL.DEBUG);
     logger.log(`📄 File dropped for flashing: '${filePath}'`, flash.Logger.LOG_LEVEL.DEBUG);

--- a/preload.js
+++ b/preload.js
@@ -14,9 +14,9 @@ window.addEventListener('DOMContentLoaded', () => {
 contextBridge.exposeInMainWorld(
     "api", {
         invoke: (channel, data = null) => {
-            let validChannels = ["on-install", "on-file-selected", "on-get-devices"];
+            let validChannels = ["on-install", "on-custom-install", "on-get-devices"];
             if(!validChannels.includes(channel)) return;
-            // ipcRenderer.invoke accesses ipcMain.handle channels like 'on-file-selected'
+            // ipcRenderer.invoke accesses ipcMain.handle channels like 'on-custom-install'
             // make sure to include this return statement or you won't get your Promise back
             return ipcRenderer.invoke(channel, data);
         },

--- a/preload.js
+++ b/preload.js
@@ -28,3 +28,9 @@ contextBridge.exposeInMainWorld(
         }
     }
 );
+
+contextBridge.exposeInMainWorld(
+    "electron", {
+        openDialog: (method, config) => ipcRenderer.invoke('dialog', method, config)
+    }
+);

--- a/renderer.js
+++ b/renderer.js
@@ -25,6 +25,11 @@ const showErrorInStatusText = (err, timeout = 4000) => {
   }, timeout);
 };
 
+const showDialogMessageBox = (title, message) => {
+  const dialogConfig = {title: title, message: message};
+  electron.openDialog('showMessageBox', dialogConfig);
+};
+
 const flashFirmwareFromFile = (filePath) => {
     disableFlashingInteractions();
     disableDeviceListInteractions();
@@ -37,7 +42,8 @@ const flashFirmwareFromFile = (filePath) => {
 
     window.api.invoke('on-custom-install', data).then(function (result) {
         console.log(result);
-        statusTextAnimator.showStatusText(result, 5000);
+        statusTextAnimator.clearStatusText();
+        showDialogMessageBox("Success", result);
         disableFlashingInteractions();
         // Give the device some time to reboot
         refreshDeviceList(2000);
@@ -132,7 +138,8 @@ installButton.addEventListener('click', () => {
     window.api.invoke('on-install', data)
         .then((result) => {
             console.log(result);
-            statusTextAnimator.showStatusText(result, 5000);
+            statusTextAnimator.clearStatusText();
+            showDialogMessageBox("Success", result);
             disableFlashingInteractions();
             // Give the device some time to reboot
             refreshDeviceList(2000);

--- a/renderer.js
+++ b/renderer.js
@@ -35,7 +35,7 @@ const flashFirmwareFromFile = (filePath) => {
       filePath : filePath
     };
 
-    window.api.invoke('on-file-selected', data).then(function (result) {
+    window.api.invoke('on-custom-install', data).then(function (result) {
         console.log(result);
         statusTextAnimator.showStatusText(result, 5000);
         disableFlashingInteractions();


### PR DESCRIPTION
This PR fixes the automatic installation on Portenta C33 that was broken because a file with different extension was expected (.dfu vs .bin) from the host.
It also adds a dialog box for when the installation was successful.