### PR TITLE
Add support for native usb discovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-2019]
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         include:
           - os: windows-2019
             dependencies: npm install
@@ -23,10 +22,12 @@ jobs:
             dependencies: sudo apt-get install libusb-dev && sudo apt-get install libudev-dev && npm install -g node-addon-api && npm install
           - os: macos-latest
             # dependencies: brew install python-setuptools && npm install -g node-addon-api && npm install
-            dependencies: npm install
+            dependencies: brew install python-setuptools && npm install
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
+    - name: debug
+      run: python3 -V && python -V
     - uses: actions/checkout@v3
     - uses: actions/setup-node@master
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,19 @@ jobs:
           - os: windows-2019
             dependencies: npm install
           - os: ubuntu-latest
+            # build-essential libudev-dev are required by usb package
             dependencies: sudo apt-get install build-essential libudev-dev && npm install
           - os: macos-latest
+            # python-setuptools includes distutils required by node-gyp
             dependencies: brew install python-setuptools && npm install
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@master
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
     - name: install dependencies
       run: ${{ matrix.dependencies }}
-    - name: debug
-      run: ls -l node_modules/usb/node_modules/
     - name: build
       run: npm run make      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
           - os: windows-2019
             dependencies: npm install
           - os: ubuntu-latest
-            dependencies: sudo apt-get install libusb-dev && sudo apt-get install libudev-dev && npm install
+            dependencies: sudo apt-get install libusb-dev && sudo apt-get install libudev-dev && npm install -g node-addon-api && npm install
           - os: macos-latest
-            dependencies: brew install python-setuptools && npm install
+            dependencies: brew install python-setuptools && npm install -g node-addon-api && npm install
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        # os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [macos-latest]
         include:
           - os: windows-2019
             dependencies: npm install
           - os: ubuntu-latest
+            # build-essential libudev-dev
             dependencies: sudo apt-get install libusb-dev && sudo apt-get install libudev-dev && npm install -g node-addon-api && npm install
           - os: macos-latest
-            dependencies: brew install python-setuptools && npm install -g node-addon-api && npm install
+            # dependencies: brew install python-setuptools && npm install -g node-addon-api && npm install
+            dependencies: npm install
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-2019]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         include:
-          # - os: windows-2019
-          #   dependencies: npm install
+          - os: windows-2019
+            dependencies: npm install
           - os: ubuntu-latest
-          #   # build-essential libudev-dev
             dependencies: sudo apt-get install build-essential libudev-dev && npm install
-          #   dependencies: sudo apt-get install libusb-dev && npm install
-          # - os: macos-latest
-          #   dependencies: brew install python-setuptools && npm install
+          - os: macos-latest
+            dependencies: brew install python-setuptools && npm install
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,26 +13,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        # os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest]
         include:
-          - os: windows-2019
-            dependencies: npm install
+          # - os: windows-2019
+          #   dependencies: npm install
           - os: ubuntu-latest
-            # build-essential libudev-dev
-            dependencies: sudo apt-get install libusb-dev && sudo apt-get install libudev-dev && npm install -g node-addon-api && npm install
-          - os: macos-latest
-            # dependencies: brew install python-setuptools && npm install -g node-addon-api && npm install
-            dependencies: brew install python-setuptools && npm install
+          #   # build-essential libudev-dev
+            dependencies: sudo apt-get install build-essential libudev-dev && npm install
+          #   dependencies: sudo apt-get install libusb-dev && npm install
+          # - os: macos-latest
+          #   dependencies: brew install python-setuptools && npm install
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
-    - name: debug
-      run: python3 -V && python -V
     - uses: actions/checkout@v3
     - uses: actions/setup-node@master
       with:
         node-version: 18
     - name: install dependencies
       run: ${{ matrix.dependencies }}
+    - name: debug
+      run: ls -l node_modules/usb/node_modules/
     - name: build
       run: npm run make      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,11 @@ jobs:
       matrix:
         config:
           - os: windows-2019
+            dependencies: npm install
           - os: ubuntu-latest
+            dependencies: apt-get install libusb-dev && apt-get install libudev-dev && npm install
           - os: macos-latest
+            dependencies: brew install python-setuptools && npm install
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90
     steps:
@@ -25,6 +28,6 @@ jobs:
       with:
         node-version: 18
     - name: install dependencies
-      run: pip install setuptools && npm install
+      run: ${{ matrix.config.dependencies }}
     - name: build
-      run: npm run make
+      run: npm run make      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,6 @@ jobs:
       with:
         node-version: 18
     - name: install dependencies
-      run: npm install
+      run: pip install setuptools && npm install
     - name: build
       run: npm run make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
+        os: [ubuntu-latest, macos-latest, windows-2019]
+        include:
           - os: windows-2019
             dependencies: npm install
           - os: ubuntu-latest
-            dependencies: apt-get install libusb-dev && apt-get install libudev-dev && npm install
+            dependencies: sudo apt-get install libusb-dev && sudo apt-get install libudev-dev && npm install
           - os: macos-latest
             dependencies: brew install python-setuptools && npm install
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
     - uses: actions/checkout@v3
@@ -28,6 +29,6 @@ jobs:
       with:
         node-version: 18
     - name: install dependencies
-      run: ${{ matrix.config.dependencies }}
+      run: ${{ matrix.dependencies }}
     - name: build
       run: npm run make      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         node-version: 18
     - name: install dependencies
       shell: bash
-      run: npm install    
+      run: ${{ matrix.dependencies }}
     - name: install signing certificate (macOS)
       if: ${{ runner.OS == 'macOS' }}
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@master
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
     - name: install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-sign-pc]
         include:
+          - os: windows-sign-pc
+            dependencies: npm install
+          - os: ubuntu-latest
+            dependencies: sudo apt-get install build-essential libudev-dev && npm install
           - os: macos-latest
+            dependencies: brew install python-setuptools && npm install
             publish-flags: --arch=x64,arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ git clone https://github.com/arduino/lab-micropython-installer.git
 cd micropython-installer-arduino
 
 # Install python setuptools for gyp used in node-usb
-brew install python-setuptools # on macOS
-sudo apt-get install python-setuptools # on Linux
+pip install setuptools
+# Alternatively:
+# brew install python-setuptools # on macOS
+# sudo apt-get install python-setuptools # on Linux
 
 # Install dependencies
 npm install

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ git clone https://github.com/arduino/lab-micropython-installer.git
 # Go into the repository
 cd micropython-installer-arduino
 
+# Install python setuptools for gyp used in node-usb
+brew install python-setuptools # on macOS
+sudo apt-get install python-setuptools # on Linux
+
 # Install dependencies
 npm install
 

--- a/check-validity-macos.sh
+++ b/check-validity-macos.sh
@@ -3,8 +3,7 @@
 # This script can be used to check the validity of a codesigned app on macOS.
 # It runs both codesign and Gatekeeper assessments.
 # Example usage: ./check-validity-macos.sh ""./out/MicroPython Installer-darwin-x64/MicroPython Installer.app"
-
-codesign --verify --verbose=1 "$1"
+codesign --verify --deep --strict --verbose=2 "$1"
 if [ $? -ne 0 ]; then
     echo "❌ Codesign verification failed. Exiting..."
     exit 1

--- a/css/item-selection.css
+++ b/css/item-selection.css
@@ -1,7 +1,7 @@
 .item-selection-list {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: stretch;
     flex-direction: row;
     gap: var(--main-flexbox-gap);
 }
@@ -17,7 +17,7 @@
     border: none;
     background-color: #F8F8F8;
     width: 165px;
-    height: 150px;
+    min-height: 150px;
     cursor: pointer;
     user-select: none;
 }
@@ -30,4 +30,10 @@
 .selection-item-label {
     font-size: 0.9rem;
     margin-top: 0.5rem;
+}
+
+.selection-item-details-label {
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+    color: #666666;
 }

--- a/firmware-flash/index.js
+++ b/firmware-flash/index.js
@@ -2,9 +2,7 @@ import DeviceManager from './logic/deviceManager.js';
 import * as descriptors from './logic/descriptors.js';
 import Logger from './logic/logger.js';
 import Device from './logic/device.js';
-import SerialDeviceFinder from './logic/deviceDiscovery/serialDeviceFinder.js';
-import PicotoolDeviceFinder from './logic/deviceDiscovery/picotoolDeviceFinder.js';
-import DFUDeviceFinder from './logic/deviceDiscovery/dfuDeviceFinder.js';
+import USBDeviceFinder from './logic/deviceDiscovery/usbDeviceFinder.js';
 
 /// The amount of time to wait for the device to become available in bootloader mode.
 /// This is only used for devices that can't be detected in bootloader mode through their serial port.
@@ -89,8 +87,6 @@ const deviceManager = new DeviceManager();
 for (const descriptor of Object.values(descriptors)) {
     deviceManager.addDeviceDescriptor(descriptor);
 }
-deviceManager.addDeviceFinder(new SerialDeviceFinder());
-deviceManager.addDeviceFinder(new PicotoolDeviceFinder());
-deviceManager.addDeviceFinder(new DFUDeviceFinder());
+deviceManager.addDeviceFinder(new USBDeviceFinder());
 
 export { Device, Logger, flashFirmware, flashMicroPythonFirmware, getDeviceList, getFirstFoundDevice, deviceManager };

--- a/firmware-flash/logic/deviceDescriptor.js
+++ b/firmware-flash/logic/deviceDescriptor.js
@@ -8,6 +8,8 @@ export class DeviceDescriptor {
         this.firmwareExtension = firmwareExtension;
         this.onFlashFirmware = null;
         this.onReset = null;
+        
+        // TODO: This can probably removed now that we use libusb to detect devices.
         // Currently used to skip the wait for device step when the device 
         // cannot be detected via its serial port or DFU interface.
         this.skipWaitForDevice = false;
@@ -20,6 +22,13 @@ export class DeviceDescriptor {
         return Object.values(this.getDefaultIDs().pids);
     }
 
+    /**
+     * @brief Returns all the alternative product IDs as an array of numbers.
+     * The boards have multiple product IDs depending on the firmware they run.
+     * The alternative product IDs are used when the device has a different VID when running
+     * a different firmware. For example, the Arduino Nano RP2040 has a different VID when it runs the native bootloader.
+     * @returns {Array} An array of integers representing the alternative product IDs.
+     */
     getAlternativeProductIDList() {
         return Object.values(this.getAlternativeIDs().pids);
     }

--- a/firmware-flash/logic/deviceDiscovery/deviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/deviceFinder.js
@@ -2,6 +2,12 @@ import Logger from "../logger.js";
 
 class DeviceFinder {
 
+    constructor() {
+        this._logger = undefined;
+        this.onDeviceConnected = undefined;
+        this.onDeviceDisconnected = undefined;
+    }
+
     get logger() {
         if(this._logger === undefined) {
             return Logger.defaultLogger;

--- a/firmware-flash/logic/deviceDiscovery/usbDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/usbDeviceFinder.js
@@ -1,0 +1,56 @@
+import SerialDeviceFinder from './serialDeviceFinder.js';
+import Device from '../device.js';
+import DeviceFinder from './deviceFinder.js';
+import USB from 'usb';
+
+class USBDeviceFinder extends DeviceFinder {
+
+    constructor() {
+        super();
+        // Use the serial device finder to add the serial port 
+        // and serial number of the USB device.
+        this.serialDeviceFinder = new SerialDeviceFinder();
+
+        USB.usb.once('attach', async (usbDevice) => {
+            if(!this.onDeviceConnected ) return;
+
+            const device = await this.deviceFromUSBDescriptor(usbDevice.deviceDescriptor);
+            if(device) this.onDeviceConnected(device);            
+        });
+        USB.usb.once('detach', async (usbDevice) => {
+            if(!this.onDeviceDisconnected) return;
+            const device = await this.deviceFromUSBDescriptor(usbDevice.deviceDescriptor);
+            if(device) this.onDeviceDisconnected(device);
+        });
+    }
+
+    async deviceFromUSBDescriptor(descriptor) {
+        if(descriptor.idVendor === undefined || descriptor.idProduct === undefined) return null;
+        const serialDevices = await this.serialDeviceFinder.getDeviceList();
+
+        const vendorID = descriptor.idVendor;
+        const productID = descriptor.idProduct;
+        const serialDevice = serialDevices.find((device) => device.vendorID === vendorID && device.productID === productID);
+        const serialPort = serialDevice ? serialDevice.serialPort : null;
+        const serialNumber = serialDevice ? serialDevice.serialNumber : null;
+        const newDevice = new Device(vendorID, productID, serialPort, serialNumber);
+        return newDevice;
+    }
+
+    async getDeviceList() {
+        let devices = [];
+        const usbDevices = USB.getDeviceList();        
+
+        for (const usbDevice of usbDevices) {
+            const descriptor = usbDevice.deviceDescriptor;
+            const newDevice = await this.deviceFromUSBDescriptor(descriptor);
+            
+            if(newDevice){
+                devices.push(newDevice);
+            }
+        }
+        return devices;
+    }
+}
+
+export default USBDeviceFinder;

--- a/firmware-flash/logic/deviceDiscovery/usbDeviceFinder.js
+++ b/firmware-flash/logic/deviceDiscovery/usbDeviceFinder.js
@@ -36,7 +36,10 @@ class USBDeviceFinder extends DeviceFinder {
         const serialDevices = await this.serialDeviceFinder.getDeviceList();
 
         const serialNumber = deviceInfo.serialNumber;
-        const serialDevice = serialDevices.find((device) => device.vendorID === deviceInfo.vendorId && device.productID === deviceInfo.productId);
+        const serialDevice = serialDevices.find((device) => device.vendorID === deviceInfo.vendorId 
+                                                    && device.productID === deviceInfo.productId
+                                                    && device.serialNumber === serialNumber
+                                                );
         const serialPort = serialDevice ? serialDevice.serialPort : null;
         const newDevice = new Device(deviceInfo.vendorId, deviceInfo.productId, serialPort, serialNumber);
         return newDevice;

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -22,16 +22,18 @@ class DeviceManager {
     addDeviceFinder(deviceFinder) {
         deviceFinder.onDeviceConnected = async () => {
             this.logger?.log(`🔌 Device connected`, Logger.LOG_LEVEL.DEBUG);
+            await this.refreshDeviceList();
+            
             if(this.onDeviceListChanged){
-                await this.refreshDeviceList();
                 this.onDeviceListChanged();
             }
         };
         
         deviceFinder.onDeviceDisconnected = async () => {
             this.logger?.log(`🔌 Device disconnected`, Logger.LOG_LEVEL.DEBUG);
+            await this.refreshDeviceList();
+
             if(this.onDeviceListChanged){
-                await this.refreshDeviceList();
                 this.onDeviceListChanged();
             }
         };

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -139,7 +139,8 @@ class DeviceManager {
                     // Only add the device if it is not already in the list.
                     if (!this.devices.find(device => 
                                             device.getVendorID() === foundDevice.getVendorID() && 
-                                            device.getProductID() === foundDevice.getProductID())) {
+                                            device.getProductID() === foundDevice.getProductID() &&
+                                            device.getSerialNumber() === foundDevice.getSerialNumber())) {
                         this.devices.push(foundDevice);
                     } else {
                         this.logger?.log(`⏭️ ${deviceFinder.constructor.name}: Device with VID ${foundDevice.getVendorID()} and PID ${foundDevice.getProductID()} already exists in list. Skipping.`, Logger.LOG_LEVEL.DEBUG);

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -20,6 +20,21 @@ class DeviceManager {
     }
 
     addDeviceFinder(deviceFinder) {
+        deviceFinder.onDeviceConnected = (device) => {
+            const vidPid = `${device.getVendorID()}:${device.getProductID()}`;
+            this.logger?.log(`🔌 Device connected: ${vidPid}`, Logger.LOG_LEVEL.DEBUG);
+            if(this.onDeviceConnected){
+                this.onDeviceConnected(device);
+            }
+        };
+        
+        deviceFinder.onDeviceDisconnected = (device) => {
+            const vidPid = `${device.getVendorID()}:${device.getProductID()}`;
+            this.logger?.log(`🔌 Device disconnected: ${vidPid}`, Logger.LOG_LEVEL.DEBUG);
+            if(this.onDeviceDisconnected){
+                this.onDeviceDisconnected(device);
+            }
+        };
         this.deviceFinders.push(deviceFinder);
     }
 
@@ -118,6 +133,8 @@ class DeviceManager {
                 if (deviceDescriptor) {
                     foundDevice.setDeviceDescriptor(deviceDescriptor);
                     foundDevice.deviceManager = this;
+                    
+                    // Only add the device if it is not already in the list.
                     if (!this.devices.find(device => 
                                             device.getVendorID() === foundDevice.getVendorID() && 
                                             device.getProductID() === foundDevice.getProductID())) {

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -20,18 +20,18 @@ class DeviceManager {
     }
 
     addDeviceFinder(deviceFinder) {
-        deviceFinder.onDeviceConnected = (device) => {
-            const vidPid = `${device.getVendorID()}:${device.getProductID()}`;
-            this.logger?.log(`🔌 Device connected: ${vidPid}`, Logger.LOG_LEVEL.DEBUG);
+        deviceFinder.onDeviceConnected = async () => {
+            this.logger?.log(`🔌 Device connected`, Logger.LOG_LEVEL.DEBUG);
             if(this.onDeviceListChanged){
+                await this.refreshDeviceList();
                 this.onDeviceListChanged();
             }
         };
         
-        deviceFinder.onDeviceDisconnected = (device) => {
-            const vidPid = `${device.getVendorID()}:${device.getProductID()}`;
-            this.logger?.log(`🔌 Device disconnected: ${vidPid}`, Logger.LOG_LEVEL.DEBUG);
+        deviceFinder.onDeviceDisconnected = async () => {
+            this.logger?.log(`🔌 Device disconnected`, Logger.LOG_LEVEL.DEBUG);
             if(this.onDeviceListChanged){
+                await this.refreshDeviceList();
                 this.onDeviceListChanged();
             }
         };

--- a/firmware-flash/logic/deviceManager.js
+++ b/firmware-flash/logic/deviceManager.js
@@ -23,16 +23,16 @@ class DeviceManager {
         deviceFinder.onDeviceConnected = (device) => {
             const vidPid = `${device.getVendorID()}:${device.getProductID()}`;
             this.logger?.log(`🔌 Device connected: ${vidPid}`, Logger.LOG_LEVEL.DEBUG);
-            if(this.onDeviceConnected){
-                this.onDeviceConnected(device);
+            if(this.onDeviceListChanged){
+                this.onDeviceListChanged();
             }
         };
         
         deviceFinder.onDeviceDisconnected = (device) => {
             const vidPid = `${device.getVendorID()}:${device.getProductID()}`;
             this.logger?.log(`🔌 Device disconnected: ${vidPid}`, Logger.LOG_LEVEL.DEBUG);
-            if(this.onDeviceDisconnected){
-                this.onDeviceDisconnected(device);
+            if(this.onDeviceListChanged){
+                this.onDeviceListChanged();
             }
         };
         this.deviceFinders.push(deviceFinder);

--- a/firmware-flash/package-lock.json
+++ b/firmware-flash/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "node-fetch": "^3.3.0",
         "serialport": "^12.0.0",
-        "usb": "^2.12.1"
+        "usb": "^2.13.0"
       }
     },
     "node_modules/@serialport/binding-mock": {
@@ -348,17 +348,25 @@
       }
     },
     "node_modules/usb": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.12.1.tgz",
-      "integrity": "sha512-hgtoSQUFuMXVJBApelpUTiX7ZB83MQCbYeHTBsHftA2JG7YZ76ycwIgKQhkhKqVY76C8K6xJscHpF7Ep0eG3pQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.13.0.tgz",
+      "integrity": "sha512-pTNKyxD1DfC1DYu8kFcIdpE8f33e0c2Sbmmi0HEs28HTVC555uocvYR1g5DDv4CBibacCh4BqRyYZJylN4mBbw==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/w3c-web-usb": "^1.0.6",
-        "node-addon-api": "^7.0.0",
+        "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.5.0"
       },
       "engines": {
         "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
+      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/firmware-flash/package-lock.json
+++ b/firmware-flash/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^3.3.0",
-        "serialport": "^12.0.0"
+        "serialport": "^12.0.0",
+        "usb": "^2.12.1"
       }
     },
     "node_modules/@serialport/binding-mock": {
@@ -202,6 +203,11 @@
         "url": "https://opencollective.com/serialport/donate"
       }
     },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -339,6 +345,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.12.1.tgz",
+      "integrity": "sha512-hgtoSQUFuMXVJBApelpUTiX7ZB83MQCbYeHTBsHftA2JG7YZ76ycwIgKQhkhKqVY76C8K6xJscHpF7Ep0eG3pQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^7.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/firmware-flash/package.json
+++ b/firmware-flash/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "node-fetch": "^3.3.0",
     "serialport": "^12.0.0",
-    "usb": "^2.12.1"
+    "usb": "^2.13.0"
   }
 }

--- a/firmware-flash/package.json
+++ b/firmware-flash/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/arduino/lab-micropython-installer#readme",
   "dependencies": {
     "node-fetch": "^3.3.0",
-    "serialport": "^12.0.0"
+    "serialport": "^12.0.0",
+    "usb": "^2.12.1"
   }
 }

--- a/forge.config.js
+++ b/forge.config.js
@@ -91,7 +91,7 @@ module.exports = {
       
       // Remove files under node_modules\usb\prebuilds because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
-      const usbPrebuildsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/usb/prebuilds/');
+      const usbPrebuildsDir = path.join(buildPath, 'node_modules/usb/prebuilds/');
 
       [nodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir].forEach(dir => {
         if (fs.existsSync(dir)) {

--- a/forge.config.js
+++ b/forge.config.js
@@ -97,7 +97,10 @@ module.exports = {
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
       const usbPrebuildsDir = path.join(buildPath, 'node_modules/usb/prebuilds/');
 
-      [nodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir].forEach(dir => {
+      // Remove temporary build files of usb module to speed up code signing under macOS
+      const usbObjectsDir = path.join(buildPath, 'node_modules/usb/build/Release/obj.target/');
+
+      [nodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir, usbObjectsDir].forEach(dir => {
         if (fs.existsSync(dir)) {
           fs.rmSync(dir, { recursive: true });
         }

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,8 +1,13 @@
 const os = require('os');
 const path = require('path');
 
+const platform = os.platform();
+const architecture = os.arch();
+const applicationName = 'MicroPython-Installer';
+
 let filesToExclude = [];
-switch (os.platform()) {
+
+switch (platform) {
   case 'win32':
     filesToExclude = ["(\/firmware-flash\/bin\/linux$)",
                       "(\/firmware-flash\/bin\/darwin$)",
@@ -61,12 +66,11 @@ module.exports = {
         });
       }
       return results;
-    },
     }
   },
   packagerConfig: {
     icon: './assets/app-icon',
-    name: 'MicroPython-Installer',
+    name: applicationName, // Name cannot contain spaces because gyp doesn't support them
     executableName: 'micropython-installer',
     ignore: filesToExclude,
     prune: true,
@@ -93,7 +97,7 @@ module.exports = {
       callback();
     }],
     osxSign: {
-      app: './out/MicroPython Installer-darwin-x64/MicroPython Installer.app',
+      app: './out/' + applicationName + '-darwin-' + architecture + '/' + applicationName + '.app',
       optionsForFile: (filePath) => {
         return {
           entitlements: './config/entitlements.plist'
@@ -103,7 +107,7 @@ module.exports = {
     },
     osxNotarize: process.env.APPLE_API_KEY_PATH ? {
       tool: 'notarytool',
-      appPath: './out/MicroPython Installer-darwin-x64/MicroPython Installer.app',
+      appPath: './out/' + applicationName + '-darwin-' + architecture + '/' + applicationName + '.app',
       appleApiKey: process.env.APPLE_API_KEY_PATH,
       appleApiKeyId: process.env.APPLE_API_KEY_ID,
       appleApiIssuer: process.env.APPLE_API_ISSUER,

--- a/forge.config.js
+++ b/forge.config.js
@@ -82,12 +82,12 @@ module.exports = {
       // because the cause notarization issues and they are not needed after building.
       // One of the files is a symlink to python which is outside of the app bundle.
       // SEE: https://github.com/nodejs/node-gyp/issues/2713#issuecomment-1400959609
-      const nodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
+      const nodeGypBinsDir = path.join(buildPath, 'node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
       
       // Remove files under node_modules/@serialport/bindings-cpp/prebuilds/
       // because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
-      const nodeGypPrebuildsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/prebuilds/');
+      const nodeGypPrebuildsDir = path.join(buildPath, 'node_modules/@serialport/bindings-cpp/prebuilds/');
       
       // Remove files under node_modules\usb\prebuilds because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.

--- a/forge.config.js
+++ b/forge.config.js
@@ -79,6 +79,10 @@ module.exports = {
     ignore: filesToExclude,
     prune: true,
     derefSymlinks: true,
+    protocols: [ {
+      name: 'micropython-installer',
+      schemes: ['micropython-installer']
+    }],
     afterCopy: [(buildPath, electronVersion, platform, arch, callback) => {
       const fs = require('fs');
       const path = require('path');

--- a/forge.config.js
+++ b/forge.config.js
@@ -89,21 +89,24 @@ module.exports = {
     afterCopy: [(buildPath, electronVersion, platform, arch, callback) => {
       const fs = require('fs');
       const path = require('path');
+      
+      // UPDATE: Seems to be no longer needed, keeping it for reference
       // Remove files under node_modules/@serialport/bindings-cpp/build/node_gyp_bins/
       // because the cause notarization issues and they are not needed after building.
       // One of the files is a symlink to python which is outside of the app bundle.
       // SEE: https://github.com/nodejs/node-gyp/issues/2713#issuecomment-1400959609
       const serialportNodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
 
-      // Remove files under node_modules/usb/build/node_gyp_bins/
-      // because the cause notarization issues and they are not needed after building.
-      // One of the files is a symlink node_gyp_bins/python3 which points outside of the app bundle.
-      const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/usb/build/node_gyp_bins/');
-      
+      // UPDATE: Seems to be no longer needed, keeping it for reference
       // Remove files under node_modules/@serialport/bindings-cpp/prebuilds/
       // because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
       const nodeGypPrebuildsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/prebuilds/');
+      
+      // Remove files under node_modules/usb/build/node_gyp_bins/
+      // because the cause notarization issues and they are not needed after building.
+      // One of the files is a symlink node_gyp_bins/python3 which points outside of the app bundle.
+      const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/usb/build/node_gyp_bins/');
       
       // Remove files under node_modules\usb\prebuilds because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.

--- a/forge.config.js
+++ b/forge.config.js
@@ -3,8 +3,14 @@ const path = require('path');
 
 const platform = os.platform();
 const architecture = os.arch();
-const applicationName = 'MicroPython-Installer'; // Name cannot contain spaces because gyp doesn't support them
 
+const applicationNames = {
+  'darwin': 'MicroPython-Installer',
+  'win32': 'MicroPython-Installer',
+  'linux': 'micropython-installer'
+};
+
+const applicationName = applicationNames[platform];
 let filesToExclude = [];
 
 switch (platform) {
@@ -75,10 +81,6 @@ module.exports = {
   packagerConfig: {
     icon: './assets/app-icon',
     name: applicationName, // Name cannot contain spaces because gyp doesn't support them
-    executableName: 'micropython-installer',
-    extendInfo: {
-      "CFBundleDisplayName": applicationName,
-    },
     ignore: filesToExclude,
     prune: true,
     derefSymlinks: true,

--- a/forge.config.js
+++ b/forge.config.js
@@ -66,7 +66,7 @@ module.exports = {
   },
   packagerConfig: {
     icon: './assets/app-icon',
-    name: 'MicroPython Installer',
+    name: 'MicroPython-Installer',
     executableName: 'micropython-installer',
     ignore: filesToExclude,
     prune: true,

--- a/forge.config.js
+++ b/forge.config.js
@@ -32,7 +32,7 @@ switch (os.platform()) {
 // Source code of firmware-flash is not needed as it's already installed as a dependency
 filesToExclude.push("^\/firmware-flash");
 
-renamingRules = {
+const distributableRenamingRules = {
   "darwin": { from: 'darwin', to: 'macOS' },
   "win32": { from: 'Setup', to: 'Windows-Setup' },
   "linux": { from: 'amd64', to: 'Linux' }
@@ -41,26 +41,27 @@ renamingRules = {
 // Check options at https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html
 module.exports = {
   hooks: {
-    postMake: async (forgeConfig, options) => {
+    postMake: async (forgeConfig, results) => {
       const fs = require('fs');
 
-      for(let option of options) {
-        option.artifacts.forEach((artifact, index) => {  
+      for(let result of results) {
+        result.artifacts.forEach((artifact, index) => {  
           const fileName = path.basename(artifact);          
-          const renameInfo = renamingRules[option.platform];
-          const targetName = fileName.replace(renameInfo.from, renameInfo.to);
+          const renameRule = distributableRenamingRules[result.platform];
+          const targetName = fileName.replace(renameRule.from, renameRule.to);
           console.log(`Renaming ${fileName} to ${targetName}`);
           const targetPath = path.join(path.dirname(artifact), targetName);
 
           try {
             fs.renameSync(artifact, targetPath);
-            option.artifacts[index] = targetPath;
+            result.artifacts[index] = targetPath;
           } catch (err) {
             console.error(err);
           }
         });
       }
-      return options;
+      return results;
+    },
     }
   },
   packagerConfig: {

--- a/forge.config.js
+++ b/forge.config.js
@@ -91,8 +91,7 @@ module.exports = {
       // Remove files under node_modules/usb/build/node_gyp_bins/
       // because the cause notarization issues and they are not needed after building.
       // One of the files is a symlink node_gyp_bins/python3 which points outside of the app bundle.
-      const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/usb/build/node_gyp_bins/');
-      // const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/usb/build/node_gyp_bins/');
+      const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/usb/build/node_gyp_bins/');
       
       // Remove files under node_modules/@serialport/bindings-cpp/prebuilds/
       // because they are not needed after building and they cause code signing issues under Windows.

--- a/forge.config.js
+++ b/forge.config.js
@@ -112,7 +112,7 @@ module.exports = {
       // Remove temporary build files of usb module to speed up code signing under macOS
       const usbObjectsDir = path.join(buildPath, 'node_modules/usb/build/Release/obj.target/');
 
-      [serialportNodeGypBinsDir, usbNodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir, usbObjectsDir].forEach(dir => {
+      [usbNodeGypBinsDir, usbPrebuildsDir, usbObjectsDir].forEach(dir => {
         if (fs.existsSync(dir)) {
           fs.rmSync(dir, { recursive: true });
         }

--- a/forge.config.js
+++ b/forge.config.js
@@ -86,12 +86,12 @@ module.exports = {
       // because the cause notarization issues and they are not needed after building.
       // One of the files is a symlink to python which is outside of the app bundle.
       // SEE: https://github.com/nodejs/node-gyp/issues/2713#issuecomment-1400959609
-      const nodeGypBinsDir = path.join(buildPath, 'node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
+      const nodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
       
       // Remove files under node_modules/@serialport/bindings-cpp/prebuilds/
       // because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
-      const nodeGypPrebuildsDir = path.join(buildPath, 'node_modules/@serialport/bindings-cpp/prebuilds/');
+      const nodeGypPrebuildsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/prebuilds/');
       
       // Remove files under node_modules\usb\prebuilds because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.

--- a/forge.config.js
+++ b/forge.config.js
@@ -83,12 +83,17 @@ module.exports = {
       // One of the files is a symlink to python which is outside of the app bundle.
       // SEE: https://github.com/nodejs/node-gyp/issues/2713#issuecomment-1400959609
       const nodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
+      
       // Remove files under node_modules/@serialport/bindings-cpp/prebuilds/
       // because they are not needed after building and they cause code signing issues under Windows.
       // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
       const nodeGypPrebuildsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/prebuilds/');
+      
+      // Remove files under node_modules\usb\prebuilds because they are not needed after building and they cause code signing issues under Windows.
+      // signtool.exe would e.g. try to sign android-arm\node.napi.armv7.node which will in fail.
+      const usbPrebuildsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/usb/prebuilds/');
 
-      [nodeGypBinsDir, nodeGypPrebuildsDir].forEach(dir => {
+      [nodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir].forEach(dir => {
         if (fs.existsSync(dir)) {
           fs.rmSync(dir, { recursive: true });
         }

--- a/forge.config.js
+++ b/forge.config.js
@@ -76,6 +76,9 @@ module.exports = {
     icon: './assets/app-icon',
     name: applicationName, // Name cannot contain spaces because gyp doesn't support them
     executableName: 'micropython-installer',
+    extendInfo: {
+      "CFBundleDisplayName": applicationName,
+    },
     ignore: filesToExclude,
     prune: true,
     derefSymlinks: true,

--- a/forge.config.js
+++ b/forge.config.js
@@ -53,6 +53,10 @@ module.exports = {
         result.artifacts.forEach((artifact, index) => {  
           const fileName = path.basename(artifact);          
           const renameRule = distributableRenamingRules[result.platform];
+          
+          if(!fileName.includes(renameRule.from)) {
+            return;
+          }
           const targetName = fileName.replace(renameRule.from, renameRule.to);
           console.log(`Renaming ${fileName} to ${targetName}`);
           const targetPath = path.join(path.dirname(artifact), targetName);

--- a/forge.config.js
+++ b/forge.config.js
@@ -86,7 +86,13 @@ module.exports = {
       // because the cause notarization issues and they are not needed after building.
       // One of the files is a symlink to python which is outside of the app bundle.
       // SEE: https://github.com/nodejs/node-gyp/issues/2713#issuecomment-1400959609
-      const nodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
+      const serialportNodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/@serialport/bindings-cpp/build/node_gyp_bins/');
+
+      // Remove files under node_modules/usb/build/node_gyp_bins/
+      // because the cause notarization issues and they are not needed after building.
+      // One of the files is a symlink node_gyp_bins/python3 which points outside of the app bundle.
+      const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/firmware-flash/node_modules/usb/build/node_gyp_bins/');
+      // const usbNodeGypBinsDir = path.join(buildPath, 'node_modules/usb/build/node_gyp_bins/');
       
       // Remove files under node_modules/@serialport/bindings-cpp/prebuilds/
       // because they are not needed after building and they cause code signing issues under Windows.
@@ -100,7 +106,7 @@ module.exports = {
       // Remove temporary build files of usb module to speed up code signing under macOS
       const usbObjectsDir = path.join(buildPath, 'node_modules/usb/build/Release/obj.target/');
 
-      [nodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir, usbObjectsDir].forEach(dir => {
+      [serialportNodeGypBinsDir, usbNodeGypBinsDir, nodeGypPrebuildsDir, usbPrebuildsDir, usbObjectsDir].forEach(dir => {
         if (fs.existsSync(dir)) {
           fs.rmSync(dir, { recursive: true });
         }

--- a/forge.config.js
+++ b/forge.config.js
@@ -81,6 +81,7 @@ module.exports = {
   packagerConfig: {
     icon: './assets/app-icon',
     name: applicationName, // Name cannot contain spaces because gyp doesn't support them
+    arch: 'all',
     ignore: filesToExclude,
     prune: true,
     derefSymlinks: true,
@@ -88,6 +89,9 @@ module.exports = {
       name: 'micropython-installer',
       schemes: ['micropython-installer']
     }],
+    // osxUniversal: {
+    //   outAppPath: './out/' + applicationName + '-darwin-universal.app',
+    // },
     afterCopy: [(buildPath, electronVersion, platform, arch, callback) => {
       const fs = require('fs');
       const path = require('path');

--- a/forge.config.js
+++ b/forge.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const platform = os.platform();
 const architecture = os.arch();
-const applicationName = 'MicroPython-Installer';
+const applicationName = 'MicroPython-Installer'; // Name cannot contain spaces because gyp doesn't support them
 
 let filesToExclude = [];
 

--- a/main.js
+++ b/main.js
@@ -108,6 +108,7 @@ ipcMain.handle('on-install', async (event, data) => {
     });
 });
 
+// Handle event for when the renderer requests the list of devices
 ipcMain.handle('on-get-devices', async (event, arg) => {
     return new Promise(async function (resolve, reject) {
         await flash.deviceManager.refreshDeviceList();
@@ -121,10 +122,12 @@ ipcMain.handle('on-get-devices', async (event, arg) => {
     });
 });
 
+// Handle native dialog events from renderer
 ipcMain.handle('dialog', (event, method, params) => {
     dialog[method](win, params);
 });
 
+// Handle auto updater events
 function handleSquirrelEvent() {
     if (process.argv.length === 1) {
         return false;

--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ app.whenReady().then(async () => {
     logger.setLogLevel(flash.Logger.LOG_LEVEL.DEBUG);
     flash.deviceManager.onDeviceListChanged = async () => {
         const devices = await flash.deviceManager.getDeviceList();
-        const pojos = devices.map(device => device.toPlainObject());
+        const pojos = await Promise.all(devices.map(device => device.toPlainObject()));
         win.webContents.send("on-device-list-changed", pojos);
     }
     createWindow()
@@ -124,7 +124,7 @@ ipcMain.handle('on-install', async (event, data) => {
 ipcMain.handle('on-get-devices', async (event, arg) => {
     return new Promise(async function (resolve, reject) {
         const devices = await flash.getDeviceList();
-        const pojos = devices.map(device => device.toPlainObject());
+        const pojos = await Promise.all(devices.map(device => device.toPlainObject()));
         resolve(pojos);
     });
 });

--- a/main.js
+++ b/main.js
@@ -43,6 +43,11 @@ app.whenReady().then(async () => {
     logger = flash.Logger.defaultLogger;
     logger.onLog = forwardOutput;
     logger.setLogLevel(flash.Logger.LOG_LEVEL.DEBUG);
+    flash.deviceManager.onDeviceListChanged = async () => {
+        const devices = await flash.deviceManager.getDeviceList();
+        const pojos = devices.map(device => device.toPlainObject());
+        win.webContents.send("on-device-list-changed", pojos);
+    }
     createWindow()
 })
 

--- a/main.js
+++ b/main.js
@@ -118,7 +118,6 @@ ipcMain.handle('on-install', async (event, data) => {
 // Handle event for when the renderer requests the list of devices
 ipcMain.handle('on-get-devices', async (event, arg) => {
     return new Promise(async function (resolve, reject) {
-        await flash.deviceManager.refreshDeviceList();
         const devices = await flash.getDeviceList();
         const pojos = devices.map(device => device.toPlainObject());
         resolve(pojos);

--- a/main.js
+++ b/main.js
@@ -95,6 +95,11 @@ ipcMain.handle('on-install', async (event, data) => {
         const selectedDevice = flash.deviceManager.getDevice(deviceData.vendorID, deviceData.productID);
         const selectedDeviceName = selectedDevice?.deviceDescriptor.name;
         
+        // Enable this code block to test the UI without flashing the firmware
+        // await flash.deviceManager.wait(2000);
+        // resolve(`🎉 Successfully flashed firmware onto ${selectedDeviceName}. You may need to reboot the board.`);
+        // return;
+        
         try {
             if(!selectedDevice){
                 reject("❌ Selected device is not available. Make sure the device is connected and try again.");

--- a/main.js
+++ b/main.js
@@ -113,12 +113,8 @@ ipcMain.handle('on-get-devices', async (event, arg) => {
     return new Promise(async function (resolve, reject) {
         await flash.deviceManager.refreshDeviceList();
         const devices = await flash.getDeviceList();
-        if (devices.length === 0) {
-            resolve([]);
-        } else {
-            const pojos = devices.map(device => device.toPlainObject());
-            resolve(pojos);
-        }
+        const pojos = devices.map(device => device.toPlainObject());
+        resolve(pojos);
     });
 });
 

--- a/main.js
+++ b/main.js
@@ -88,18 +88,20 @@ ipcMain.handle('on-install', async (event, data) => {
     const { deviceData, usePreviewBuild } = data;
     return new Promise(async function (resolve, reject) {
         const selectedDevice = flash.deviceManager.getDevice(deviceData.vendorID, deviceData.productID);
+        const selectedDeviceName = selectedDevice?.deviceDescriptor.name;
+        
         try {
             if(!selectedDevice){
-                reject("❌ Selected device is not available. Click 'Refresh' to update the list of devices.");
+                reject("❌ Selected device is not available. Make sure the device is connected and try again.");
                 return;
             }
             if (await flash.flashMicroPythonFirmware(selectedDevice, usePreviewBuild)) {
-                resolve("🎉 Done! You may need to reboot the board.");
+                resolve(`🎉 Successfully flashed firmware onto ${selectedDeviceName}. You may need to reboot the board.`);
             } else {
                 // Due to a bug in Electron the error message is reformatted and needs
                 // to be cleaned up in the renderer process.
                 // See: https://github.com/electron/electron/issues/24427
-                reject("❌ Failed to flash firmware.");
+                reject(`❌ Failed to flash firmware onto ${selectedDeviceName}.`);
             }
         } catch (error) {
             logger.log(error, flash.Logger.LOG_LEVEL.DEBUG);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micropython-installer",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micropython-installer",
-      "version": "1.4.0",
+      "version": "1.5.0-beta.0",
       "license": "ISC",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
         "update-electron-app": "^2.0.1"
       },
       "devDependencies": {
-        "@electron-forge/cli": "^6.2.1",
-        "@electron-forge/maker-deb": "^6.1.1",
-        "@electron-forge/maker-squirrel": "^6.1.1",
-        "@electron-forge/maker-zip": "^6.1.1",
-        "@electron-forge/publisher-github": "^6.1.1",
-        "electron": "^23.1.3"
+        "@electron-forge/cli": "^7.4.0",
+        "@electron-forge/maker-deb": "^7.4.0",
+        "@electron-forge/maker-squirrel": "^7.4.0",
+        "@electron-forge/maker-zip": "^7.4.0",
+        "@electron-forge/publisher-github": "^7.4.0",
+        "electron": "^30.0.6"
       }
     },
     "firmware-flash": {
@@ -74,9 +74,9 @@
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "node_modules/@electron-forge/cli": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.2.1.tgz",
-      "integrity": "sha512-AyCJ1m7LBgttgUTS3kDwiBLhPHJ+6mFwoMSqu847EJ4Fe1DJ1Hi6gnMsSga7Mv4KsF7iA23Ss1fo+3TGZnvrWw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.4.0.tgz",
+      "integrity": "sha512-a+zZv3ja/IxkJzNyx4sOHSZv6DPV85S0PEVF6pcRjUpbDL5r+DxjRFsNc0Nq4UIWyFm1nw7RWoPdd9uDst4Tvg==",
       "dev": true,
       "funding": [
         {
@@ -89,14 +89,14 @@
         }
       ],
       "dependencies": {
-        "@electron-forge/core": "6.2.1",
-        "@electron-forge/shared-types": "6.2.1",
-        "@electron/get": "^2.0.0",
+        "@electron-forge/core": "7.4.0",
+        "@electron-forge/shared-types": "7.4.0",
+        "@electron/get": "^3.0.0",
         "chalk": "^4.0.0",
         "commander": "^4.1.1",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
-        "listr2": "^5.0.3",
+        "listr2": "^7.0.2",
         "semver": "^7.2.1"
       },
       "bin": {
@@ -105,21 +105,69 @@
         "electron-forge-vscode-win": "script/vscode.cmd"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/cli/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
+    "node_modules/@electron-forge/cli/node_modules/@electron/get": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.0.0.tgz",
+      "integrity": "sha512-hLv4BYFiyrNRI+U0Mm2X7RxCCdJLkDUn8GCEp9QJzbLpZRko+UaLlCjOMkj6TEtirNLPyBA7y1SeGfnpOB21aQ==",
       "dev": true,
       "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron-forge/cli/node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@electron-forge/cli/node_modules/@electron/get/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron-forge/cli/node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@electron-forge/cli/node_modules/@electron/get/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@electron-forge/cli/node_modules/fs-extra": {
@@ -173,9 +221,9 @@
       }
     },
     "node_modules/@electron-forge/core": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.2.1.tgz",
-      "integrity": "sha512-udjU8r9dzuV/dPMPxONmkWYoqM0uY6ezpdjTLgO9aNdWTbBeBLIOMVT0jdx7GBoTuPu6ul/VhDEFNUaojEOrVA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.4.0.tgz",
+      "integrity": "sha512-pYHKpB2CKeQgWsb+gox+FPkEvP+6Q2zGj2eZtgZRtKppoWIXrHIpOtcm6FllJ/gZ5u4AsQzVIYReAHGaBa0osw==",
       "dev": true,
       "funding": [
         {
@@ -188,28 +236,30 @@
         }
       ],
       "dependencies": {
-        "@electron-forge/core-utils": "6.2.1",
-        "@electron-forge/maker-base": "6.2.1",
-        "@electron-forge/plugin-base": "6.2.1",
-        "@electron-forge/publisher-base": "6.2.1",
-        "@electron-forge/shared-types": "6.2.1",
-        "@electron-forge/template-base": "6.2.1",
-        "@electron-forge/template-vite": "6.2.1",
-        "@electron-forge/template-webpack": "6.2.1",
-        "@electron-forge/template-webpack-typescript": "6.2.1",
-        "@electron/get": "^2.0.0",
+        "@electron-forge/core-utils": "7.4.0",
+        "@electron-forge/maker-base": "7.4.0",
+        "@electron-forge/plugin-base": "7.4.0",
+        "@electron-forge/publisher-base": "7.4.0",
+        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/template-base": "7.4.0",
+        "@electron-forge/template-vite": "7.4.0",
+        "@electron-forge/template-vite-typescript": "7.4.0",
+        "@electron-forge/template-webpack": "7.4.0",
+        "@electron-forge/template-webpack-typescript": "7.4.0",
+        "@electron-forge/tracer": "7.4.0",
+        "@electron/get": "^3.0.0",
+        "@electron/packager": "^18.3.1",
         "@electron/rebuild": "^3.2.10",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
         "debug": "^4.3.1",
-        "electron-packager": "^17.1.1",
         "fast-glob": "^3.2.7",
         "filenamify": "^4.1.0",
         "find-up": "^5.0.0",
         "fs-extra": "^10.0.0",
         "got": "^11.8.5",
         "interpret": "^3.1.1",
-        "listr2": "^5.0.3",
+        "listr2": "^7.0.2",
         "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "node-fetch": "^2.6.7",
@@ -223,16 +273,16 @@
         "yarn-or-npm": "^3.0.1"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/core-utils": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-6.2.1.tgz",
-      "integrity": "sha512-mJUpy8mZ7/l1BddReFrNZyM5iNEuYwjpeIqZ2E0E/hQPH26QreAV3rPfTj7WhA3V69ftmn++QRt82pNZFhHVEg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.4.0.tgz",
+      "integrity": "sha512-9RLG0F9SX466TpkaTcW+V15KmnGuTpmr7NKMRlngtHXmnkBUJz4Mxp1x33WZLgL90dJrxrRgHSfVBtA4lstDPw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1",
+        "@electron-forge/shared-types": "7.4.0",
         "@electron/rebuild": "^3.2.10",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -244,21 +294,7 @@
         "yarn-or-npm": "^3.0.1"
       },
       "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/core-utils/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/core-utils/node_modules/fs-extra": {
@@ -288,13 +324,10 @@
       }
     },
     "node_modules/@electron-forge/core-utils/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -303,52 +336,56 @@
       }
     },
     "node_modules/@electron-forge/core-utils/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron-forge/core/node_modules/@electron-forge/maker-base": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.2.1.tgz",
-      "integrity": "sha512-LnvGtTJ/RNojKdUKktYEcbLqPggXdMBs1uscQRgXkI3XnVGdEi+/j5+Eg5ka4d6FnsaUkz//U5yhPtNFhDbNSw==",
+    "node_modules/@electron-forge/core/node_modules/@electron/get": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.0.0.tgz",
+      "integrity": "sha512-hLv4BYFiyrNRI+U0Mm2X7RxCCdJLkDUn8GCEp9QJzbLpZRko+UaLlCjOMkj6TEtirNLPyBA7y1SeGfnpOB21aQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1",
-        "fs-extra": "^10.0.0",
-        "which": "^2.0.2"
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
       }
     },
-    "node_modules/@electron-forge/core/node_modules/@electron-forge/publisher-base": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.2.1.tgz",
-      "integrity": "sha512-clrrEPsamoe4543smfyZUBp2IRSZ4EEhdj/bm0zmODS2qs/V1cCEf7y8P29huxMskT5bXDxSzothG72or3b2WQ==",
+    "node_modules/@electron-forge/core/node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@electron-forge/core/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
+    "node_modules/@electron-forge/core/node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@electron-forge/core/node_modules/fs-extra": {
@@ -365,7 +402,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/@electron-forge/core/node_modules/jsonfile": {
+    "node_modules/@electron-forge/core/node_modules/fs-extra/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
@@ -377,14 +414,20 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@electron-forge/core/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+    "node_modules/@electron-forge/core/node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron-forge/core/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -392,27 +435,18 @@
         "node": ">=10"
       }
     },
-    "node_modules/@electron-forge/core/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron-forge/maker-base": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.1.1.tgz",
-      "integrity": "sha512-qEW8vuSq6/r1rKh7JENK9yGmueymMzbm817GDk5usHia5o7otHYY4JMkdzZaKww56Ed/Ege2ch6LEYqYGTfl/Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.4.0.tgz",
+      "integrity": "sha512-LwWS4VPdwjISl1KpLhmM1Qr1M3sRTTQ/RsX+GlFd7cQ1W/FsgxMjaTG4Od1d+a5CGVTh3s6X2g99TSUfxjOveg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.1.1",
+        "@electron-forge/shared-types": "7.4.0",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/maker-base/node_modules/fs-extra": {
@@ -442,45 +476,45 @@
       }
     },
     "node_modules/@electron-forge/maker-base/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron-forge/maker-deb": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.1.1.tgz",
-      "integrity": "sha512-Qk/QMBwWP/D6Fx7+VU54xHec47R9CYg0TCaRtQ1KeBNFdJ3DpwCARr966/IJqEUxX7y8vv8Awc8HvKDPxbpIUA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.4.0.tgz",
+      "integrity": "sha512-npWea3IpGeu96xNqJpsCOYX6V4E+HY6u/okeTUzUOMX96UteT14MecdUefMam158glRTX84k2ryh7WcBoOa4mg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "6.1.1",
-        "@electron-forge/shared-types": "6.1.1"
+        "@electron-forge/maker-base": "7.4.0",
+        "@electron-forge/shared-types": "7.4.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       },
       "optionalDependencies": {
-        "electron-installer-debian": "^3.0.0"
+        "electron-installer-debian": "^3.2.0"
       }
     },
     "node_modules/@electron-forge/maker-squirrel": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.1.1.tgz",
-      "integrity": "sha512-YA7EY7He5FGGiwNlcOLSHwtrDFmq1XZ+0sKHy/xLu0Q8JZzo15WQ0vwJJEIAxL8KAtjwfhyV5VAWI6w0elr/jg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.4.0.tgz",
+      "integrity": "sha512-mCQyufnSNfjffiKho59ZqVg4W601zGOl6h01OyfDwjOU/G4iQtpnnDEOXGe26q7OVT5ORb1WDnfyGgBeJ6Ge7g==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "6.1.1",
-        "@electron-forge/shared-types": "6.1.1",
+        "@electron-forge/maker-base": "7.4.0",
+        "@electron-forge/shared-types": "7.4.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       },
       "optionalDependencies": {
-        "electron-winstaller": "^5.0.0"
+        "electron-winstaller": "^5.3.0"
       }
     },
     "node_modules/@electron-forge/maker-squirrel/node_modules/fs-extra": {
@@ -519,19 +553,19 @@
       }
     },
     "node_modules/@electron-forge/maker-zip": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.1.1.tgz",
-      "integrity": "sha512-3T2bIbYhKl3Z/VyeN+X7+7U+HhgaCtBCfDi0k/Ga7CoUpge2uJS/+yjfGJdwFk4TbWhS3sNkZV2mFMKhx/rlmQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.4.0.tgz",
+      "integrity": "sha512-UGbMdpuK/P29x1FFRWNOs3bNz+7QNFWVWyTM5hcWqib66cNuUmoaPifQyuwW2POIrIohrxlzLK87/i9Zc8g4dA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "6.1.1",
-        "@electron-forge/shared-types": "6.1.1",
+        "@electron-forge/maker-base": "7.4.0",
+        "@electron-forge/shared-types": "7.4.0",
         "cross-zip": "^4.0.0",
         "fs-extra": "^10.0.0",
         "got": "^11.8.5"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/maker-zip/node_modules/fs-extra": {
@@ -570,61 +604,50 @@
       }
     },
     "node_modules/@electron-forge/plugin-base": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.2.1.tgz",
-      "integrity": "sha512-8mVbFgTlxQKDZ7jzeHyWrzOSiv/DpE29flPLgpyeFuz/zbC7oLNdxBCYo7WptQgI+HArphqehKUBf1UOkXmRPg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.4.0.tgz",
+      "integrity": "sha512-LcTNtEc2YaWvhhqWVIfdJ+J0/krSgc2dqYAHhOH2aLUSm9End3dKO/PZ1Y6DPsiPiJKHnSLBJ/XBN/16NY4Sjw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1"
+        "@electron-forge/shared-types": "7.4.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/plugin-base/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/publisher-base": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.1.1.tgz",
-      "integrity": "sha512-vxGzx2G7bWhz2G091MzNh+LHGrOM4gmp8FqW2VNpFJfFEYODr6D9KxitUihKAWc79bwG+YywvISXEMy5IBQu0Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.4.0.tgz",
+      "integrity": "sha512-PiJk4RfaC55SnVnteLW2ZIQNM9DpGOi6YoUn5t8i9UcVp2rFIdya7bJY/b9u1hwubm4d5+TdypMVEuJjM44CJQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.1.1"
+        "@electron-forge/shared-types": "7.4.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/publisher-github": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-github/-/publisher-github-6.1.1.tgz",
-      "integrity": "sha512-CAsSGDwSe9Rp3llgFe4T5MFrZ0WM3TCTLD9ylqmo9EddN6wqLnF+OQ2HmMhwmxbxFg0/ysnAyJRyTc5T/seV4Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-github/-/publisher-github-7.4.0.tgz",
+      "integrity": "sha512-hrxKNssJyU8Yuz0qv384y5RKojMG0nWeG7/kidjp8PX/RnqjGRU/JJ0Worl28g8LGiLt5R5JIfNLngLaFMn8tg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/publisher-base": "6.1.1",
-        "@electron-forge/shared-types": "6.1.1",
+        "@electron-forge/publisher-base": "7.4.0",
+        "@electron-forge/shared-types": "7.4.0",
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-retry": "^3.0.9",
+        "@octokit/request-error": "^2.0.5",
         "@octokit/rest": "^18.0.11",
         "@octokit/types": "^6.1.2",
+        "chalk": "^4.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
+        "log-symbols": "^4.0.0",
         "mime-types": "^2.1.25"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/publisher-github/node_modules/fs-extra": {
@@ -663,47 +686,34 @@
       }
     },
     "node_modules/@electron-forge/shared-types": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.1.1.tgz",
-      "integrity": "sha512-sFQQ2ldMq5mlNv4m7lZOZLf9aOn6MLNc8QVeTzOBQ+psxI3mVTDjb+/Lhs/jU8dm2igVfEqAmlj57Gi+C4u4Vw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.4.0.tgz",
+      "integrity": "sha512-5Ehy6enUjBaU08odf9u9TOhmOVXlqobzMvKUixtkdAWgV1XZAUJmn+p21xhj0IkO92MQiXMGv66w9pDNjRT8uQ==",
       "dev": true,
       "dependencies": {
+        "@electron-forge/tracer": "7.4.0",
+        "@electron/packager": "^18.3.1",
         "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
+        "listr2": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/template-base": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-6.2.1.tgz",
-      "integrity": "sha512-hSMaefJRptpszPsZLvEfHV22KO6/XK0kJ6Lota1x3xQEFQs4IpCwUv446JE5hde+5Fukw5vZawbK2m937Te24Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.4.0.tgz",
+      "integrity": "sha512-3YWdRSGzQfQPQkQxStn2wkJ/SuNGGKo9slwFJGvqMV+Pbx3/M/hYi9sMXOuaqVZgeaBp8Ap27yFPxaIIOC3vcA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1",
+        "@electron-forge/shared-types": "7.4.0",
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
         "username": "^5.1.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/template-base/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/template-base/node_modules/fs-extra": {
@@ -733,40 +743,75 @@
       }
     },
     "node_modules/@electron-forge/template-base/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron-forge/template-vite": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-6.2.1.tgz",
-      "integrity": "sha512-t05p8ZWtkixjuUFJpaupq2t+ap8vjPjULO2knKC12TqWTxo53M8lKwx0f7h0zvgyqWdtEGQr8KiVfeFS0Lh3jA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.4.0.tgz",
+      "integrity": "sha512-YPVyCGiBKmZPCxK/Bd2louV3PBcxI2nT2+tRKP+mlEHOWrxbZIfmZSR2lIAFvK/ALKlwUKROdmlwyi7ZcdT7JQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1",
-        "@electron-forge/template-base": "6.2.1",
+        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/template-base": "7.4.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/template-vite/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
+    "node_modules/@electron-forge/template-vite-typescript": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.4.0.tgz",
+      "integrity": "sha512-wdByG807VWcUd81E6572b/G/Ki8gb+GrCIWxO7Cl3qBa+yNaU1sHhBwB1RyTbQy1r8ubSBtsWrRD1J/yzHKWoQ==",
       "dev": true,
       "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
+        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/template-base": "7.4.0",
+        "fs-extra": "^10.0.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-vite-typescript/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron-forge/template-vite-typescript/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron-forge/template-vite-typescript/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron-forge/template-vite/node_modules/fs-extra": {
@@ -796,54 +841,40 @@
       }
     },
     "node_modules/@electron-forge/template-vite/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron-forge/template-webpack": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-6.2.1.tgz",
-      "integrity": "sha512-u2/Cm6HjCah07larN1npHDG1dhDZMyqdDnPDh0iQNv+BEV6kCMSHX/8R9Uc7uIpkRVj+uCfcYBnkoKHKbUgKcQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.4.0.tgz",
+      "integrity": "sha512-W558AEGwQrwEtKIbIJPPs0LIsaC/1Vncj5NgqKehEMJjBb0KQq4hwBu/6dauQrfun4jRCOp7LV+OVrf5XPJ7QA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1",
-        "@electron-forge/template-base": "6.2.1",
+        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/template-base": "7.4.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-6.2.1.tgz",
-      "integrity": "sha512-8dXu54OsvfeBVGFyHfzVaBlxH+dPFxgLKu+/gsip82OEmLghXWyfvwhpXBw3rhxqG8V2/nbxDYUghSJackWZYA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.4.0.tgz",
+      "integrity": "sha512-O5gwjNSGFNRdJWyiCtevcOBDPAMhgOPvLORh9qR1GcjyTutWwHWmZzycqH+MmkhpQPgrAYDEeipXcOQhSbzNZA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "6.2.1",
-        "@electron-forge/template-base": "6.2.1",
+        "@electron-forge/shared-types": "7.4.0",
+        "@electron-forge/template-base": "7.4.0",
         "fs-extra": "^10.0.0"
       },
       "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
-    "node_modules/@electron-forge/template-webpack-typescript/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
+        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript/node_modules/fs-extra": {
@@ -873,26 +904,12 @@
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@electron-forge/template-webpack/node_modules/@electron-forge/shared-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.2.1.tgz",
-      "integrity": "sha512-kLazG5XUAqb3Duyhq7XyGluINRwCQRaIiuvHwlvnZYYu6NZQTz9xUm6tQ9v05EtFblUx2iRjY67DJRZSt3dzTQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron/rebuild": "^3.2.10",
-        "electron-packager": "^17.1.1",
-        "listr2": "^5.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/template-webpack/node_modules/fs-extra": {
@@ -922,21 +939,32 @@
       }
     },
     "node_modules/@electron-forge/template-webpack/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/asar": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.3.tgz",
-      "integrity": "sha512-wmOfE6szYyqZhRIiLH+eyZEp+bGcJI0OD/SCvSUrfBE0jvauyGYO2ZhpWxmNCcDojKu5DYrsVqT5BOCZZ01XIg==",
+    "node_modules/@electron-forge/tracer": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.4.0.tgz",
+      "integrity": "sha512-F4jbnDn4yIZjmky1FZ6rgBKTM05AZQQfHkyJW2hdS4pDKJjdKAqWytoZKDi1/S6Cr6tN+DD0TFGD3V0i6HPHYQ==",
       "dev": true,
       "dependencies": {
-        "chromium-pickle-js": "^0.2.0",
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.10.tgz",
+      "integrity": "sha512-mvBSwIBUeiRscrCeJE1LwctAriBj65eUDm0Pc11iE5gRwzkmsdbS7FnZ1XUWjpSeQWL1L5g12Fc/SchPM9DUOw==",
+      "dev": true,
+      "dependencies": {
         "commander": "^5.0.0",
         "glob": "^7.1.6",
         "minimatch": "^3.0.4"
@@ -946,9 +974,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      },
-      "optionalDependencies": {
-        "@types/glob": "^7.1.1"
       }
     },
     "node_modules/@electron/asar/node_modules/commander": {
@@ -981,13 +1006,14 @@
       }
     },
     "node_modules/@electron/notarize": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-1.2.3.tgz",
-      "integrity": "sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.3.2.tgz",
+      "integrity": "sha512-zfayxCe19euNwRycCty1C7lF7snk9YwfRpB5M8GLr1a4ICH63znxaPNAubrMvj0yDvVozqfgsdYpXVUnpWBDpg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
-        "fs-extra": "^9.0.1"
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -1021,18 +1047,18 @@
       }
     },
     "node_modules/@electron/notarize/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/osx-sign": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.4.tgz",
-      "integrity": "sha512-xfhdEcIOfAZg7scZ9RQPya1G1lWo8/zMCwUXAulq0SfY7ONIW+b9qGyKdMyuMctNYwllrIS+vmxfijSfjeh97g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.0.tgz",
+      "integrity": "sha512-TEXhxlYSDRr9JWK5nWdOv5MtuUdaZ412uxIIEQ0hLt80o0HYWtQJBlW5QmrQDMtebzATaOjKG9UfCzLyA90zWQ==",
       "dev": true,
       "dependencies": {
         "compare-version": "^0.1.2",
@@ -1077,18 +1103,145 @@
       }
     },
     "node_modules/@electron/osx-sign/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@electron/packager": {
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.2.tgz",
+      "integrity": "sha512-orjylavppgIh24qkNpWm2B/LQUpCS/YLOoKoU+eMK/hJgIhShLDsusPIQzgUGVwNCichu8/zPAGfdQZXHG0gtw==",
+      "dev": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "@electron/get": "^3.0.0",
+        "@electron/notarize": "^2.1.0",
+        "@electron/osx-sign": "^1.0.5",
+        "@electron/universal": "^2.0.1",
+        "@electron/windows-sign": "^1.0.0",
+        "debug": "^4.0.1",
+        "extract-zip": "^2.0.0",
+        "filenamify": "^4.1.0",
+        "fs-extra": "^11.1.0",
+        "galactus": "^1.0.0",
+        "get-package-info": "^1.0.0",
+        "junk": "^3.1.0",
+        "parse-author": "^2.0.0",
+        "plist": "^3.0.0",
+        "resedit": "^2.0.0",
+        "resolve": "^1.1.6",
+        "semver": "^7.1.3",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "electron-packager": "bin/electron-packager.js"
+      },
+      "engines": {
+        "node": ">= 16.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron/packager?sponsor=1"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/@electron/get": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.0.0.tgz",
+      "integrity": "sha512-hLv4BYFiyrNRI+U0Mm2X7RxCCdJLkDUn8GCEp9QJzbLpZRko+UaLlCjOMkj6TEtirNLPyBA7y1SeGfnpOB21aQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@electron/rebuild": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.2.10.tgz",
-      "integrity": "sha512-SUBM6Mwi3yZaDFQjZzfGKpYTtOp9m60glounwX6tfGeVc/ZOl4jbquktUcyy7gYSLDWFLtKkftkY2xgMJZLQgg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.0.tgz",
+      "integrity": "sha512-zF4x3QupRU3uNGaP5X1wjpmcjfw1H87kyqZ00Tc3HvriV+4gmOGuvQjGNkrJuXdsApssdNyVwLsy+TaeTGGcVw==",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -1097,17 +1250,17 @@
         "detect-libc": "^2.0.1",
         "fs-extra": "^10.0.0",
         "got": "^11.7.0",
-        "lzma-native": "^8.0.5",
-        "node-abi": "^3.0.0",
-        "node-api-version": "^0.1.4",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
         "node-gyp": "^9.0.0",
         "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
         "semver": "^7.3.5",
         "tar": "^6.0.5",
         "yargs": "^17.0.1"
       },
       "bin": {
-        "electron-rebuild": "lib/src/cli.js"
+        "electron-rebuild": "lib/cli.js"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -1140,13 +1293,10 @@
       }
     },
     "node_modules/@electron/rebuild/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1155,67 +1305,53 @@
       }
     },
     "node_modules/@electron/rebuild/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/universal": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.4.tgz",
-      "integrity": "sha512-BdhBgm2ZBnYyYRLRgOjM5VHkyFItsbggJ0MHycOjKWdFGYwK97ZFXH54dTvUWEfha81vfvwr5On6XBjt99uDcg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
       "dev": true,
       "dependencies": {
-        "@electron/asar": "^3.2.1",
-        "@malept/cross-spawn-promise": "^1.1.0",
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
-        "dir-compare": "^3.0.0",
-        "fs-extra": "^9.0.1",
-        "minimatch": "^3.0.4",
-        "plist": "^3.0.4"
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
       },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=16.4"
       }
     },
-    "node_modules/@electron/universal/node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
       "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/@electron/universal/node_modules/jsonfile": {
@@ -1230,10 +1366,79 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@electron/universal/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.1.2.tgz",
+      "integrity": "sha512-eXEiZjDtxW3QORCWfRUarANPRTlH9B6At4jqBZJ0NzokSGutXQUVLPA6WmGpIhDW6w2yCMdHW1EJd1HrXtU5sg==",
+      "dev": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
@@ -1316,13 +1521,10 @@
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1764,9 +1966,12 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.16.tgz",
-      "integrity": "sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA=="
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -1790,6 +1995,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1809,13 +2023,11 @@
       }
     },
     "node_modules/agentkeepalive": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
-      "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -1836,24 +2048,24 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.21.3"
+        "type-fest": "^1.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1863,12 +2075,15 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1905,13 +2120,37 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+    "node_modules/asar": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+      "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
+      "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
       "dev": true,
+      "optional": true,
+      "dependencies": {
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=10.12.0"
+      },
+      "optionalDependencies": {
+        "@types/glob": "^7.1.1"
+      }
+    },
+    "node_modules/asar/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/at-least-node": {
@@ -2047,18 +2286,6 @@
         "node": "*"
       }
     },
-    "node_modules/buffer-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
-      "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2168,16 +2395,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2203,11 +2420,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -2219,21 +2446,24 @@
       }
     },
     "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "dev": true,
       "dependencies": {
-        "restore-cursor": "^3.1.0"
+        "restore-cursor": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz",
-      "integrity": "sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2243,16 +2473,16 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
       "dev": true,
       "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
+        "slice-ansi": "^5.0.0",
+        "string-width": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2270,6 +2500,73 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -2320,9 +2617,9 @@
       }
     },
     "node_modules/colorette": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
     "node_modules/commander": {
@@ -2355,6 +2652,12 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true
     },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2367,52 +2670,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cross-spawn-windows-exe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
-      "integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "dependencies": {
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "is-wsl": "^2.2.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/cross-spawn-windows-exe/node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/cross-zip": {
@@ -2452,16 +2709,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decompress-response": {
@@ -2531,15 +2778,6 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -2547,9 +2785,9 @@
       "dev": true
     },
     "node_modules/detect-libc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2562,23 +2800,29 @@
       "optional": true
     },
     "node_modules/dir-compare": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
-      "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
       "dev": true,
       "dependencies": {
-        "buffer-equal": "^1.0.0",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/electron": {
-      "version": "23.1.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.3.tgz",
-      "integrity": "sha512-MNjuUS2K6/OxlJ0zTC77djo1R3xM038v1kUunvNFgDMZHYKpSOzOMNsPiwM2BGp+uZbkUb0nTnYafxXrM8H16w==",
+      "version": "30.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.6.tgz",
+      "integrity": "sha512-PkhEPFdpYcTzjAO3gMHZ+map7g2+xCrMDedo/L1i0ir2BRXvAB93IkTJX497U6Srb/09r2cFt+k20VPNVCdw3Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^20.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -2638,39 +2882,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/electron-installer-common/node_modules/asar": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
-      "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
-      "deprecated": "Please use @electron/asar moving forward.  There is no API change, just a package name change",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "chromium-pickle-js": "^0.2.0",
-        "commander": "^5.0.0",
-        "glob": "^7.1.6",
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "asar": "bin/asar.js"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      },
-      "optionalDependencies": {
-        "@types/glob": "^7.1.1"
-      }
-    },
-    "node_modules/electron-installer-common/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/electron-installer-common/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -2701,14 +2912,11 @@
       }
     },
     "node_modules/electron-installer-common/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
       "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2717,9 +2925,9 @@
       }
     },
     "node_modules/electron-installer-common/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -2727,9 +2935,9 @@
       }
     },
     "node_modules/electron-installer-debian": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-3.1.0.tgz",
-      "integrity": "sha512-k6KChvx0Fw8XTlCqwwbBfh19yGQaKjGdbugokmr1IpzINOm4QFyACKMTHAYFHW5LCBUZQShZD96hwxUZ+8Kx+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-3.2.0.tgz",
+      "integrity": "sha512-58ZrlJ1HQY80VucsEIG9tQ//HrTlG6sfofA3nRGr6TmkX661uJyu4cMPPh6kXW+aHdq/7+q25KyQhDrXvRL7jw==",
       "dev": true,
       "optional": true,
       "os": [
@@ -2744,7 +2952,7 @@
         "get-folder-size": "^2.0.1",
         "lodash": "^4.17.4",
         "word-wrap": "^1.2.3",
-        "yargs": "^15.0.1"
+        "yargs": "^16.0.2"
       },
       "bin": {
         "electron-installer-debian": "src/cli.js"
@@ -2776,31 +2984,34 @@
         "node": ">= 10"
       }
     },
+    "node_modules/electron-installer-debian/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-installer-debian/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/electron-installer-debian/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+    "node_modules/electron-installer-debian/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "optional": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "optional": true
     },
     "node_modules/electron-installer-debian/node_modules/fs-extra": {
       "version": "9.1.0",
@@ -2818,6 +3029,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/electron-installer-debian/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-installer-debian/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2831,72 +3052,38 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/electron-installer-debian/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+    "node_modules/electron-installer-debian/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/electron-installer-debian/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+    "node_modules/electron-installer-debian/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "p-try": "^2.0.0"
+        "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/electron-installer-debian/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -2904,9 +3091,9 @@
       }
     },
     "node_modules/electron-installer-debian/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2915,143 +3102,45 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/electron-installer-debian/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/electron-installer-debian/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/electron-installer-debian/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "optional": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
     "node_modules/electron-is-dev": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.3.0.tgz",
       "integrity": "sha512-jLttuuq8QK67n3mXmIe9pkrO7IH3LGIk12xJkhTmc852U2sCJaRAOpRGPSh+1Xnzck5v9escd9YXzuze9nGejg=="
-    },
-    "node_modules/electron-packager": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-17.1.1.tgz",
-      "integrity": "sha512-r1NDtlajsq7gf2EXgjRfblCVPquvD2yeg+6XGErOKblvxOpDi0iulZLVhgYDP4AEF1P5/HgbX/vwjlkEv7PEIQ==",
-      "dev": true,
-      "dependencies": {
-        "@electron/asar": "^3.2.1",
-        "@electron/get": "^2.0.0",
-        "@electron/notarize": "^1.2.3",
-        "@electron/osx-sign": "^1.0.1",
-        "@electron/universal": "^1.3.2",
-        "cross-spawn-windows-exe": "^1.2.0",
-        "debug": "^4.0.1",
-        "extract-zip": "^2.0.0",
-        "filenamify": "^4.1.0",
-        "fs-extra": "^10.1.0",
-        "galactus": "^0.2.1",
-        "get-package-info": "^1.0.0",
-        "junk": "^3.1.0",
-        "parse-author": "^2.0.0",
-        "plist": "^3.0.0",
-        "rcedit": "^3.0.1",
-        "resolve": "^1.1.6",
-        "semver": "^7.1.3",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "electron-packager": "bin/electron-packager.js"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      },
-      "funding": {
-        "url": "https://github.com/electron/electron-packager?sponsor=1"
-      }
-    },
-    "node_modules/electron-packager/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-packager/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-packager/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/electron-packager/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/electron-squirrel-startup": {
       "version": "1.0.0",
@@ -3075,9 +3164,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/electron-winstaller": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.1.0.tgz",
-      "integrity": "sha512-4wlZzkUm5cJNiOtp5wL804+QpygdKTKkrZJXA3sSDEI2XnCVPv0kxmxUvVw4KHBwbNS+Yox89agEr+VkR7kxww==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.3.1.tgz",
+      "integrity": "sha512-oM8BW3a8NEqG0XW+Vx3xywhk0DyDV4T0jT0zZfWt0IczNT3jHAAvQWBorF8osQDplSsCyXXyxrsrQ8cY0Slb/A==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -3085,11 +3174,14 @@
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
         "fs-extra": "^7.0.1",
-        "lodash.template": "^4.2.2",
+        "lodash": "^4.17.21",
         "temp": "^0.9.0"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
       }
     },
     "node_modules/electron-winstaller/node_modules/fs-extra": {
@@ -3108,9 +3200,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
     "node_modules/encoding": {
@@ -3161,9 +3253,9 @@
       "optional": true
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3180,6 +3272,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
     },
     "node_modules/execa": {
       "version": "1.0.0",
@@ -3237,9 +3335,9 @@
       }
     },
     "node_modules/execa/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -3290,6 +3388,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
+      "dev": true
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3310,9 +3414,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3326,9 +3430,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3396,89 +3500,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/find-up/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/firmware-flash": {
       "resolved": "firmware-flash",
       "link": true
     },
     "node_modules/flora-colossus": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-1.0.1.tgz",
-      "integrity": "sha512-d+9na7t9FyH8gBJoNDSi28mE4NgQVGGvxQ4aHtFRetjyh5SXjuus+V5EZaxFmFdXVemSOrx0lsgEl/ZMjnOWJA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.0"
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 12"
       }
     },
     "node_modules/flora-colossus/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=12"
+      }
+    },
+    "node_modules/flora-colossus/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/flora-colossus/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs-extra": {
@@ -3513,46 +3584,68 @@
       "dev": true
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "devOptional": true
-    },
-    "node_modules/galactus": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/galactus/-/galactus-0.2.1.tgz",
-      "integrity": "sha512-mDc8EQJKtxjp9PMYS3PbpjjbX3oXhBTxoGaPahw620XZBIHJ4+nvw5KN/tRtmmSDR9dypstGNvqQ3C29QGoGHQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^3.1.0",
-        "flora-colossus": "^1.0.0",
-        "fs-extra": "^4.0.0"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "devOptional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/galactus/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/galactus/node_modules/fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/galactus/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/galactus/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/gar": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
       "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "optional": true
     },
@@ -3573,6 +3666,56 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/get-caller-file": {
@@ -3827,7 +3970,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3873,6 +4016,18 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -4033,11 +4188,18 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4046,30 +4208,15 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -4082,12 +4229,15 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-glob": {
@@ -4170,18 +4320,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
@@ -4198,6 +4336,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "dev": true
     },
     "node_modules/json-buffer": {
@@ -4237,30 +4381,20 @@
       }
     },
     "node_modules/listr2": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.8.tgz",
-      "integrity": "sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-7.0.2.tgz",
+      "integrity": "sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==",
       "dev": true,
       "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^5.0.1",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.8.0",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
+        "wrap-ansi": "^8.1.0"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+        "node": ">=16.0.0"
       }
     },
     "node_modules/load-json-file": {
@@ -4279,16 +4413,18 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
@@ -4297,39 +4433,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4348,52 +4456,22 @@
       }
     },
     "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
+      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
+        "ansi-escapes": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "slice-ansi": "^5.0.0",
+        "strip-ansi": "^7.0.1",
+        "wrap-ansi": "^8.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/lowercase-keys": {
@@ -4414,24 +4492,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/lzma-native": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
-      "integrity": "sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^3.1.0",
-        "node-gyp-build": "^4.2.1",
-        "readable-stream": "^3.6.0"
-      },
-      "bin": {
-        "lzmajs": "bin/lzmajs"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -4712,9 +4772,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.34.0.tgz",
-      "integrity": "sha512-O5sNsdgxptez/bSXk2CfpTcVu4yTiFW1YcMHIVn2uAY8MksXWQeReMx63krFrj/QSyjRJ5/jIBkWvJ3/ZimdcA==",
+      "version": "3.62.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -4724,13 +4784,10 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4738,29 +4795,20 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "dev": true
-    },
     "node_modules/node-api-version": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.1.4.tgz",
-      "integrity": "sha512-KGXihXdUChwJAOHO53bv9/vXcLmdUsZ6jIptbvYvkpKfth+r7jw44JkVxQFA3kX5nQjzjmGu1uAu/xNNLNlI5g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz",
+      "integrity": "sha512-fthTTsi8CxaBXMaBAD7ST2uylwvsnYxh2PfaScwpMhos6KlSFajXQPcM4ogNE1q2s3Lbz9GCGqeIHC+C6OZnKg==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
       }
     },
     "node_modules/node-api-version/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4789,12 +4837,13 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.1.tgz",
-      "integrity": "sha512-4Q16ZCqq3g8awk6UplT7AuxQ35XN4R/yf/+wSAwcBUAjg7l58RTactWaP8fIDTi0FzI7YcVLujwExakZlfWkXg==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
       "dev": true,
       "dependencies": {
         "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
         "make-fetch-happen": "^10.0.3",
@@ -4823,13 +4872,10 @@
       }
     },
     "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4865,9 +4911,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -4975,6 +5021,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -5011,27 +5103,33 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
-        "p-try": "^1.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "dependencies": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -5050,12 +5148,12 @@
       }
     },
     "node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/parse-author": {
@@ -5092,12 +5190,12 @@
       }
     },
     "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -5134,6 +5232,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
+      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
       }
     },
     "node_modules/pend": {
@@ -5226,35 +5338,42 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/plist": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
-      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
       "dev": true,
       "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/progress": {
@@ -5324,16 +5443,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/rcedit": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-3.0.1.tgz",
-      "integrity": "sha512-XM0Jv40/y4hVAqj/MO70o/IWs4uOsaSoo2mLyk3klFDW+SStLnCtzuQu+1OBTIMGlM8CvaK9ftlYCp6DJ+cMsw==",
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
       "dev": true,
       "dependencies": {
-        "cross-spawn-windows-exe": "^1.1.0"
+        "debug": "^4.3.4"
       },
-      "engines": {
-        "node": ">= 10.0.0"
+      "bin": {
+        "read-binary-file-arch": "cli.js"
       }
     },
     "node_modules/read-pkg": {
@@ -5375,6 +5494,61 @@
         "node": ">=4"
       }
     },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5410,20 +5584,30 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+    "node_modules/resedit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.2.tgz",
+      "integrity": "sha512-UKTnq602iVe+W5SyRAQx/WdWMnlDiONfXBLFg/ur4QE4EQQ8eP7Jgm5mNXdK12kKawk1vvXPja2iXKqZiGDW6Q==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "pe-library": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -5477,16 +5661,19 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/retry": {
@@ -5509,9 +5696,9 @@
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
       "dev": true
     },
     "node_modules/rimraf": {
@@ -5567,15 +5754,6 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -5695,17 +5873,31 @@
       "dev": true
     },
     "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/smart-buffer": {
@@ -5719,16 +5911,16 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -5776,9 +5968,9 @@
       }
     },
     "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true
     },
     "node_modules/spdx-expression-parse": {
@@ -5792,16 +5984,16 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
       "dev": true
     },
     "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "optional": true
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "devOptional": true
     },
     "node_modules/ssri": {
       "version": "9.0.1",
@@ -5825,29 +6017,35 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -5931,14 +6129,14 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -5948,9 +6146,9 @@
       }
     },
     "node_modules/tar/node_modules/minipass": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
-      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5996,12 +6194,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
-    },
     "node_modules/tiny-each-async": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
@@ -6010,16 +6202,13 @@
       "optional": true
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
       "optional": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmp-promise": {
@@ -6071,12 +6260,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
-    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -6088,6 +6271,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unique-filename": {
       "version": "2.0.1",
@@ -6232,13 +6420,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -6248,10 +6429,60 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wide-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -6259,20 +6490,32 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -6305,9 +6548,9 @@
       "devOptional": true
     },
     "node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -6329,6 +6572,56 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yarn-or-npm": {
@@ -6374,9 +6667,9 @@
       }
     },
     "node_modules/yarn-or-npm/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@electron-forge/maker-squirrel": "^7.4.0",
         "@electron-forge/maker-zip": "^7.4.0",
         "@electron-forge/publisher-github": "^7.4.0",
-        "electron": "^30.0.6"
+        "electron": "^31.3.0"
       }
     },
     "firmware-flash": {
@@ -28,7 +28,7 @@
       "dependencies": {
         "node-fetch": "^3.3.0",
         "serialport": "^12.0.0",
-        "usb": "^2.12.1"
+        "usb": "^2.13.0"
       }
     },
     "firmware-flash/node_modules/data-uri-to-buffer": {
@@ -2816,9 +2816,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "30.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.6.tgz",
-      "integrity": "sha512-PkhEPFdpYcTzjAO3gMHZ+map7g2+xCrMDedo/L1i0ir2BRXvAB93IkTJX497U6Srb/09r2cFt+k20VPNVCdw3Q==",
+      "version": "31.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.3.0.tgz",
+      "integrity": "sha512-3LMRMmK4UK0A+jYSLGLYdfhc20TgY2v5jD3iGmhRZlDYj0gn7xBj/waRjlNalysZ0D2rgPvoes0wHuf5e/Bguw==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
@@ -4795,6 +4795,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
+      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-api-version": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz",
@@ -6330,25 +6338,17 @@
       }
     },
     "node_modules/usb": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.12.1.tgz",
-      "integrity": "sha512-hgtoSQUFuMXVJBApelpUTiX7ZB83MQCbYeHTBsHftA2JG7YZ76ycwIgKQhkhKqVY76C8K6xJscHpF7Ep0eG3pQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.13.0.tgz",
+      "integrity": "sha512-pTNKyxD1DfC1DYu8kFcIdpE8f33e0c2Sbmmi0HEs28HTVC555uocvYR1g5DDv4CBibacCh4BqRyYZJylN4mBbw==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/w3c-web-usb": "^1.0.6",
-        "node-addon-api": "^7.0.0",
+        "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.5.0"
       },
       "engines": {
         "node": ">=12.22.0 <13.0 || >=14.17.0"
-      }
-    },
-    "node_modules/usb/node_modules/node-addon-api": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-      "engines": {
-        "node": "^16 || ^18 || >= 20"
       }
     },
     "node_modules/username": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micropython-installer",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micropython-installer",
-      "version": "1.5.0-beta.0",
+      "version": "1.5.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,109 +27,14 @@
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^3.3.0",
-        "serialport": "^10.5.0"
-      }
-    },
-    "firmware-flash/node_modules/@serialport/binding-mock": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
-      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
-      "dependencies": {
-        "@serialport/bindings-interface": "^1.2.1",
-        "debug": "^4.3.3"
-      }
-    },
-    "firmware-flash/node_modules/@serialport/bindings-cpp": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
-      "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
-      "dependencies": {
-        "@serialport/bindings-interface": "1.2.2",
-        "@serialport/parser-readline": "^10.2.1",
-        "debug": "^4.3.2",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.3.0"
-      }
-    },
-    "firmware-flash/node_modules/@serialport/bindings-interface": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-byte-length": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
-      "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-cctalk": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
-      "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-delimiter": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-      "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-inter-byte-timeout": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
-      "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-packet-length": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
-      "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-readline": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
-      "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
-      "dependencies": {
-        "@serialport/parser-delimiter": "10.5.0"
-      }
-    },
-    "firmware-flash/node_modules/@serialport/parser-ready": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
-      "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
-      "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-slip-encoder": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
-      "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw=="
-    },
-    "firmware-flash/node_modules/@serialport/parser-spacepacket": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
-      "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg=="
-    },
-    "firmware-flash/node_modules/@serialport/stream": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
-      "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
-      "dependencies": {
-        "@serialport/bindings-interface": "1.2.2",
-        "debug": "^4.3.2"
+        "serialport": "^12.0.0",
+        "usb": "^2.12.1"
       }
     },
     "firmware-flash/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-    },
-    "firmware-flash/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      }
     },
     "firmware-flash/node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -148,16 +53,6 @@
         "fetch-blob": "^3.1.2"
       }
     },
-    "firmware-flash/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "firmware-flash/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-    },
     "firmware-flash/node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -171,32 +66,6 @@
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
-      }
-    },
-    "firmware-flash/node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
-    },
-    "firmware-flash/node_modules/serialport": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
-      "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
-      "dependencies": {
-        "@serialport/binding-mock": "10.2.2",
-        "@serialport/bindings-cpp": "10.8.0",
-        "@serialport/parser-byte-length": "10.5.0",
-        "@serialport/parser-cctalk": "10.5.0",
-        "@serialport/parser-delimiter": "10.5.0",
-        "@serialport/parser-inter-byte-timeout": "10.5.0",
-        "@serialport/parser-packet-length": "10.5.0",
-        "@serialport/parser-readline": "10.5.0",
-        "@serialport/parser-ready": "10.5.0",
-        "@serialport/parser-regex": "10.5.0",
-        "@serialport/parser-slip-encoder": "10.5.0",
-        "@serialport/parser-spacepacket": "10.5.0",
-        "@serialport/stream": "10.5.0",
-        "debug": "^4.3.3"
       }
     },
     "firmware-flash/node_modules/web-streams-polyfill": {
@@ -1617,6 +1486,200 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/@serialport/binding-mock": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+      "dependencies": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-12.0.1.tgz",
+      "integrity": "sha512-r2XOwY2dDvbW7dKqSPIk2gzsr6M6Qpe9+/Ngs94fNaNlcTRCV02PfaoDmRgcubpNVVcLATlxSxPTIDw12dbKOg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "@serialport/parser-readline": "11.0.0",
+        "debug": "4.3.4",
+        "node-addon-api": "7.0.0",
+        "node-gyp-build": "4.6.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-11.0.0.tgz",
+      "integrity": "sha512-aZLJhlRTjSmEwllLG7S4J8s8ctRAS0cbvCpO87smLvl3e4BgzbVgF6Z6zaJd3Aji2uSiYgfedCdNc4L6W+1E2g==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-11.0.0.tgz",
+      "integrity": "sha512-rRAivhRkT3YO28WjmmG4FQX6L+KMb5/ikhyylRfzWPw0nSXy97+u07peS9CbHqaNvJkMhH1locp2H36aGMOEIA==",
+      "dependencies": {
+        "@serialport/parser-delimiter": "11.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/node-addon-api": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
+    },
+    "node_modules/@serialport/bindings-interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
+      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@serialport/parser-byte-length": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-12.0.0.tgz",
+      "integrity": "sha512-0ei0txFAj+s6FTiCJFBJ1T2hpKkX8Md0Pu6dqMrYoirjPskDLJRgZGLqoy3/lnU1bkvHpnJO+9oJ3PB9v8rNlg==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-cctalk": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-12.0.0.tgz",
+      "integrity": "sha512-0PfLzO9t2X5ufKuBO34DQKLXrCCqS9xz2D0pfuaLNeTkyGUBv426zxoMf3rsMRodDOZNbFblu3Ae84MOQXjnZw==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-delimiter": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
+      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-inter-byte-timeout": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-12.0.0.tgz",
+      "integrity": "sha512-GnCh8K0NAESfhCuXAt+FfBRz1Cf9CzIgXfp7SdMgXwrtuUnCC/yuRTUFWRvuzhYKoAo1TL0hhUo77SFHUH1T/w==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-packet-length": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-12.0.0.tgz",
+      "integrity": "sha512-p1hiCRqvGHHLCN/8ZiPUY/G0zrxd7gtZs251n+cfNTn+87rwcdUeu9Dps3Aadx30/sOGGFL6brIRGK4l/t7MuQ==",
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@serialport/parser-readline": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
+      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
+      "dependencies": {
+        "@serialport/parser-delimiter": "12.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-ready": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-12.0.0.tgz",
+      "integrity": "sha512-ygDwj3O4SDpZlbrRUraoXIoIqb8sM7aMKryGjYTIF0JRnKeB1ys8+wIp0RFMdFbO62YriUDextHB5Um5cKFSWg==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-regex": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-12.0.0.tgz",
+      "integrity": "sha512-dCAVh4P/pZrLcPv9NJ2mvPRBg64L5jXuiRxIlyxxdZGH4WubwXVXY/kBTihQmiAMPxbT3yshSX8f2+feqWsxqA==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-slip-encoder": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-12.0.0.tgz",
+      "integrity": "sha512-0APxDGR9YvJXTRfY+uRGhzOhTpU5akSH183RUcwzN7QXh8/1jwFsFLCu0grmAUfi+fItCkR+Xr1TcNJLR13VNA==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-spacepacket": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-12.0.0.tgz",
+      "integrity": "sha512-dozONxhPC/78pntuxpz/NOtVps8qIc/UZzdc/LuPvVsqCoJXiRxOg6ZtCP/W58iibJDKPZPAWPGYeZt9DJxI+Q==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-12.0.0.tgz",
+      "integrity": "sha512-9On64rhzuqKdOQyiYLYv2lQOh3TZU/D3+IWCR5gk0alPel2nwpp4YwDEGiUBfrQZEdQ6xww0PWkzqth4wqwX3Q==",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "4.3.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -1713,11 +1776,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -1918,7 +1985,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "dev": true,
       "optional": true
     },
     "node_modules/bottleneck": {
@@ -2447,7 +2513,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
       "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -2494,7 +2559,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "optional": true
     },
     "node_modules/dir-compare": {
@@ -3094,7 +3158,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/escalade": {
@@ -3110,7 +3173,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -3454,7 +3516,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/galactus": {
       "version": "0.2.1",
@@ -3549,7 +3611,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -3648,7 +3709,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -3666,7 +3726,6 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3724,7 +3783,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -3769,7 +3827,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3790,7 +3848,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
@@ -3803,7 +3860,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 0.4"
@@ -4153,7 +4209,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "optional": true
     },
     "node_modules/jsonfile": {
@@ -4353,7 +4408,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4431,7 +4486,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
@@ -4762,7 +4816,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -4871,7 +4924,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 0.4"
@@ -5481,7 +5533,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -5566,14 +5617,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
       "optional": true
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
@@ -5583,6 +5632,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialport": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-12.0.0.tgz",
+      "integrity": "sha512-AmH3D9hHPFmnF/oq/rvigfiAouAKyK/TjnrkwZRYSFZxNggJxwvbAbfYrLeuvq7ktUdhuHdVdSjj852Z55R+uA==",
+      "dependencies": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "12.0.1",
+        "@serialport/parser-byte-length": "12.0.0",
+        "@serialport/parser-cctalk": "12.0.0",
+        "@serialport/parser-delimiter": "12.0.0",
+        "@serialport/parser-inter-byte-timeout": "12.0.0",
+        "@serialport/parser-packet-length": "12.0.0",
+        "@serialport/parser-readline": "12.0.0",
+        "@serialport/parser-ready": "12.0.0",
+        "@serialport/parser-regex": "12.0.0",
+        "@serialport/parser-slip-encoder": "12.0.0",
+        "@serialport/parser-spacepacket": "12.0.0",
+        "@serialport/stream": "12.0.0",
+        "debug": "4.3.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
       }
     },
     "node_modules/set-blocking": {
@@ -5725,7 +5801,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true,
       "optional": true
     },
     "node_modules/ssri": {
@@ -6006,7 +6081,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -6065,6 +6139,28 @@
       },
       "peerDependencies": {
         "electron": ">= 6.0.0"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.12.1.tgz",
+      "integrity": "sha512-hgtoSQUFuMXVJBApelpUTiX7ZB83MQCbYeHTBsHftA2JG7YZ76ycwIgKQhkhKqVY76C8K6xJscHpF7Ep0eG3pQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^7.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
       }
     },
     "node_modules/username": {
@@ -6206,7 +6302,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/yargs": {
       "version": "17.7.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "@electron-forge/maker-squirrel": "^7.4.0",
     "@electron-forge/maker-zip": "^7.4.0",
     "@electron-forge/publisher-github": "^7.4.0",
-    "electron": "^30.0.6"
+    "electron": "^31.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micropython-installer",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "description": "A tool to flash MicroPython onto supported Arduino boards.",
   "main": "main.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micropython-installer",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "A tool to flash MicroPython onto supported Arduino boards.",
   "main": "main.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "update-electron-app": "^2.0.1"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^6.2.1",
-    "@electron-forge/maker-deb": "^6.1.1",
-    "@electron-forge/maker-squirrel": "^6.1.1",
-    "@electron-forge/maker-zip": "^6.1.1",
-    "@electron-forge/publisher-github": "^6.1.1",
-    "electron": "^23.1.3"
+    "@electron-forge/cli": "^7.4.0",
+    "@electron-forge/maker-deb": "^7.4.0",
+    "@electron-forge/maker-squirrel": "^7.4.0",
+    "@electron-forge/maker-zip": "^7.4.0",
+    "@electron-forge/publisher-github": "^7.4.0",
+    "electron": "^30.0.6"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -21,7 +21,7 @@ contextBridge.exposeInMainWorld(
             return ipcRenderer.invoke(channel, data);
         },
         on: (channel, func) => {
-            let validChannels = ["on-output"];
+            let validChannels = ["on-output", "on-device-list-changed"];
             if(!validChannels.includes(channel)) return;
             // Deliberately strip event as it includes `sender`
             ipcRenderer.on(channel, (event, ...args) => func(...args));

--- a/renderer.js
+++ b/renderer.js
@@ -269,8 +269,12 @@ function displayDevices(deviceList, container) {
     container.appendChild(createDeviceSelectorItem(device));
   }
 
-  // If there is only one device, select it
-  if(deviceList.length == 1) {
+  // When the device list changes while flashing is in progress
+  // we should disable device list interactions until flashing is complete.  
+  if(flashingInProgress()) {
+    disableDeviceListInteractions();
+  } else if(deviceList.length == 1) {
+    // If there is only one device, select it
     selectDevice(container.firstElementChild);
   }
 

--- a/renderer.js
+++ b/renderer.js
@@ -27,6 +27,7 @@ const showErrorInStatusText = (err, timeout = 4000) => {
 
 const showDialogMessageBox = (title, message) => {
   const dialogConfig = {title: title, message: message};
+  // Use dialog function exposed by preload.js
   electron.openDialog('showMessageBox', dialogConfig);
 };
 
@@ -254,7 +255,7 @@ function refreshDeviceList(delay = 0) {
   displayDevices([], deviceSelectionList);
 
   if(delay > 0) {
-    // Calls itself after a delay while passing 0 as the delay.
+    // Calls itself after a delay
     setTimeout(refreshDeviceList, delay);
     return;
   }

--- a/renderer.js
+++ b/renderer.js
@@ -222,8 +222,18 @@ function createDeviceSelectorItem(device) {
 
   const deviceLabel = document.createElement("span");
   deviceLabel.classList.add("selection-item-label");
-  deviceLabel.textContent = fullDeviceName;
+  deviceLabel.textContent = device.name;
   deviceItem.appendChild(deviceLabel);
+
+  const deviceDetailsLabel = document.createElement("span");
+  deviceDetailsLabel.classList.add("selection-item-details-label");
+
+  if(device.mode == "Bootloader") {
+    deviceDetailsLabel.textContent = "🛠️ Bootloader Mode";
+  } else if (device.mode == "MicroPython") {
+    deviceDetailsLabel.textContent = "🐍 " + device.microPythonVersion + " installed";
+  }
+  deviceItem.appendChild(deviceDetailsLabel);
 
   return deviceItem;
 }

--- a/renderer.js
+++ b/renderer.js
@@ -95,6 +95,10 @@ function hideFlashProgressIndicator() {
   flashActivityIndicator.style.display = 'none';
 }
 
+function flashingInProgress() {
+  return flashActivityIndicator.style.display === 'inline-block';
+}
+
 window.api.on('on-output', (message) => {
     statusTextAnimator.showStatusText(message);
 });
@@ -238,6 +242,11 @@ function hideDeviceLoadingIndicator() {
 
 function displayDevices(deviceList, container) {
   
+  // This function is only called when the device list changes
+  // which conseqently clears the selected device.
+  // so we should disable flashing interactions until a device is selected.
+  disableFlashingInteractions();
+
   // Sort the device list by manufacturer name and device name
   deviceList.sort((deviceA, deviceB) => {
     const deviceAName = deviceA.manufacturer + deviceA.name;
@@ -269,7 +278,14 @@ function displayDevices(deviceList, container) {
 
 window.addEventListener('DOMContentLoaded', () => {
   deviceSelectionList.addEventListener("device-selected", (event) => {
-    enableFlashingInteractions();
+    // Enable flashing interactions when a device is selected
+    // and no flashing operation is in progress.
+    // This check is necessary because the device selection list
+    // may change during flashing and in case there is just one device
+    // in the list it gets selected automatically.
+    if(!flashingInProgress()) {
+      enableFlashingInteractions();
+    }
   });
   
   disableFlashingInteractions();


### PR DESCRIPTION
This PR replaces the polling based board discovery that relied on the Serial port and other tools like picotool and dfu-util to discover the board with libusb. This allows to discover all connected boards instantly and uniformly with better stability. As a result this PR also removes the refresh button from the UI.